### PR TITLE
feat(tenants): add complete tenant management system

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -18,6 +18,7 @@ from app.api.v1.endpoints import (
     gdpr,
     users,
     whatsapp,
+    tenants,
 )
 
 api_router = APIRouter()
@@ -34,6 +35,13 @@ api_router.include_router(
     users.router,
     prefix="/users",
     tags=["Users"],
+)
+
+# Tenant management
+api_router.include_router(
+    tenants.router,
+    prefix="/tenants",
+    tags=["Tenants"],
 )
 
 # Campaigns (Module B)

--- a/backend/app/api/v1/endpoints/tenants.py
+++ b/backend/app/api/v1/endpoints/tenants.py
@@ -1,0 +1,546 @@
+# =============================================================================
+# Stratum AI - Tenant Management Endpoints
+# =============================================================================
+"""
+Tenant (Organization) management endpoints.
+Provides CRUD operations for multi-tenant administration.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+from app.db.session import get_async_session
+from app.models import Tenant, User, UserRole
+from app.schemas import (
+    APIResponse,
+    PaginatedResponse,
+    TenantCreate,
+    TenantResponse,
+    TenantUpdate,
+)
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+def require_admin(request: Request) -> int:
+    """Verify user has admin role."""
+    user_role = getattr(request.state, "role", None)
+    user_id = getattr(request.state, "user_id", None)
+
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    if user_role != UserRole.ADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+
+    return user_id
+
+
+@router.get("", response_model=APIResponse[List[TenantResponse]])
+async def list_tenants(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    search: Optional[str] = Query(None, max_length=100),
+):
+    """
+    List all tenants.
+    Requires admin role for full list, otherwise returns only user's tenant.
+    """
+    user_role = getattr(request.state, "role", None)
+    tenant_id = getattr(request.state, "tenant_id", None)
+
+    query = select(Tenant).where(Tenant.is_deleted == False)
+
+    # Non-admin users can only see their own tenant
+    if user_role != UserRole.ADMIN.value:
+        query = query.where(Tenant.id == tenant_id)
+
+    # Search filter
+    if search:
+        query = query.where(
+            (Tenant.name.ilike(f"%{search}%")) |
+            (Tenant.slug.ilike(f"%{search}%"))
+        )
+
+    query = query.offset(skip).limit(limit)
+    result = await db.execute(query)
+    tenants = result.scalars().all()
+
+    return APIResponse(
+        success=True,
+        data=[
+            TenantResponse(
+                id=t.id,
+                name=t.name,
+                slug=t.slug,
+                domain=t.domain,
+                plan=t.plan,
+                plan_expires_at=t.plan_expires_at,
+                max_users=t.max_users,
+                max_campaigns=t.max_campaigns,
+                settings=t.settings or {},
+                feature_flags=t.feature_flags or {},
+                created_at=t.created_at,
+                updated_at=t.updated_at,
+            )
+            for t in tenants
+        ],
+    )
+
+
+@router.get("/current", response_model=APIResponse[TenantResponse])
+async def get_current_tenant(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get the current user's tenant."""
+    tenant_id = getattr(request.state, "tenant_id", None)
+
+    if not tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    return APIResponse(
+        success=True,
+        data=TenantResponse(
+            id=tenant.id,
+            name=tenant.name,
+            slug=tenant.slug,
+            domain=tenant.domain,
+            plan=tenant.plan,
+            plan_expires_at=tenant.plan_expires_at,
+            max_users=tenant.max_users,
+            max_campaigns=tenant.max_campaigns,
+            settings=tenant.settings or {},
+            feature_flags=tenant.feature_flags or {},
+            created_at=tenant.created_at,
+            updated_at=tenant.updated_at,
+        ),
+    )
+
+
+@router.get("/{tenant_id}", response_model=APIResponse[TenantResponse])
+async def get_tenant(
+    request: Request,
+    tenant_id: int,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get a specific tenant by ID."""
+    user_role = getattr(request.state, "role", None)
+    user_tenant_id = getattr(request.state, "tenant_id", None)
+
+    # Non-admin can only view their own tenant
+    if user_role != UserRole.ADMIN.value and tenant_id != user_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    return APIResponse(
+        success=True,
+        data=TenantResponse(
+            id=tenant.id,
+            name=tenant.name,
+            slug=tenant.slug,
+            domain=tenant.domain,
+            plan=tenant.plan,
+            plan_expires_at=tenant.plan_expires_at,
+            max_users=tenant.max_users,
+            max_campaigns=tenant.max_campaigns,
+            settings=tenant.settings or {},
+            feature_flags=tenant.feature_flags or {},
+            created_at=tenant.created_at,
+            updated_at=tenant.updated_at,
+        ),
+    )
+
+
+@router.post("", response_model=APIResponse[TenantResponse], status_code=status.HTTP_201_CREATED)
+async def create_tenant(
+    request: Request,
+    tenant_data: TenantCreate,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Create a new tenant.
+    Requires admin role.
+    """
+    require_admin(request)
+
+    # Check for duplicate slug
+    result = await db.execute(
+        select(Tenant).where(Tenant.slug == tenant_data.slug)
+    )
+    existing = result.scalar_one_or_none()
+
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Tenant with slug '{tenant_data.slug}' already exists",
+        )
+
+    # Set plan limits based on plan type
+    plan_limits = {
+        "free": {"max_users": 5, "max_campaigns": 10},
+        "starter": {"max_users": 10, "max_campaigns": 50},
+        "professional": {"max_users": 25, "max_campaigns": 200},
+        "enterprise": {"max_users": 100, "max_campaigns": 1000},
+    }
+
+    limits = plan_limits.get(tenant_data.plan, plan_limits["free"])
+
+    # Create tenant
+    tenant = Tenant(
+        name=tenant_data.name,
+        slug=tenant_data.slug,
+        domain=tenant_data.domain,
+        plan=tenant_data.plan,
+        max_users=limits["max_users"],
+        max_campaigns=limits["max_campaigns"],
+        settings={},
+        feature_flags={},
+    )
+
+    db.add(tenant)
+    await db.commit()
+    await db.refresh(tenant)
+
+    logger.info(f"Tenant created: {tenant.slug} (ID: {tenant.id})")
+
+    return APIResponse(
+        success=True,
+        data=TenantResponse(
+            id=tenant.id,
+            name=tenant.name,
+            slug=tenant.slug,
+            domain=tenant.domain,
+            plan=tenant.plan,
+            plan_expires_at=tenant.plan_expires_at,
+            max_users=tenant.max_users,
+            max_campaigns=tenant.max_campaigns,
+            settings=tenant.settings or {},
+            feature_flags=tenant.feature_flags or {},
+            created_at=tenant.created_at,
+            updated_at=tenant.updated_at,
+        ),
+        message="Tenant created successfully",
+    )
+
+
+@router.patch("/{tenant_id}", response_model=APIResponse[TenantResponse])
+async def update_tenant(
+    request: Request,
+    tenant_id: int,
+    update_data: TenantUpdate,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Update a tenant.
+    Admin can update any tenant, managers can update their own tenant.
+    """
+    user_role = getattr(request.state, "role", None)
+    user_tenant_id = getattr(request.state, "tenant_id", None)
+
+    # Check permissions
+    if user_role not in [UserRole.ADMIN.value, UserRole.MANAGER.value]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin or manager access required",
+        )
+
+    # Non-admin can only update their own tenant
+    if user_role != UserRole.ADMIN.value and tenant_id != user_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    # Update fields
+    update_dict = update_data.model_dump(exclude_unset=True)
+
+    for field, value in update_dict.items():
+        if hasattr(tenant, field):
+            setattr(tenant, field, value)
+
+    await db.commit()
+    await db.refresh(tenant)
+
+    logger.info(f"Tenant updated: {tenant.slug} (ID: {tenant.id})")
+
+    return APIResponse(
+        success=True,
+        data=TenantResponse(
+            id=tenant.id,
+            name=tenant.name,
+            slug=tenant.slug,
+            domain=tenant.domain,
+            plan=tenant.plan,
+            plan_expires_at=tenant.plan_expires_at,
+            max_users=tenant.max_users,
+            max_campaigns=tenant.max_campaigns,
+            settings=tenant.settings or {},
+            feature_flags=tenant.feature_flags or {},
+            created_at=tenant.created_at,
+            updated_at=tenant.updated_at,
+        ),
+        message="Tenant updated successfully",
+    )
+
+
+@router.delete("/{tenant_id}", response_model=APIResponse[None])
+async def delete_tenant(
+    request: Request,
+    tenant_id: int,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Soft delete a tenant.
+    Requires admin role.
+    """
+    require_admin(request)
+
+    user_tenant_id = getattr(request.state, "tenant_id", None)
+
+    # Prevent self-deletion
+    if tenant_id == user_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot delete your own tenant",
+        )
+
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    # Soft delete
+    tenant.is_deleted = True
+    await db.commit()
+
+    logger.info(f"Tenant deleted: {tenant.slug} (ID: {tenant.id})")
+
+    return APIResponse(
+        success=True,
+        message="Tenant deleted successfully",
+    )
+
+
+@router.get("/{tenant_id}/users", response_model=APIResponse[dict])
+async def get_tenant_users(
+    request: Request,
+    tenant_id: int,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Get users count and list for a tenant.
+    """
+    user_role = getattr(request.state, "role", None)
+    user_tenant_id = getattr(request.state, "tenant_id", None)
+
+    # Non-admin can only view their own tenant
+    if user_role != UserRole.ADMIN.value and tenant_id != user_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    # Get tenant
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    # Get user count
+    count_result = await db.execute(
+        select(func.count(User.id)).where(
+            User.tenant_id == tenant_id,
+            User.is_deleted == False
+        )
+    )
+    user_count = count_result.scalar()
+
+    return APIResponse(
+        success=True,
+        data={
+            "tenant_id": tenant_id,
+            "user_count": user_count,
+            "max_users": tenant.max_users,
+            "slots_available": tenant.max_users - user_count,
+        },
+    )
+
+
+@router.patch("/{tenant_id}/plan", response_model=APIResponse[TenantResponse])
+async def update_tenant_plan(
+    request: Request,
+    tenant_id: int,
+    plan: str = Query(..., regex="^(free|starter|professional|enterprise)$"),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Update tenant subscription plan.
+    Requires admin role.
+    """
+    require_admin(request)
+
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    # Update plan and limits
+    plan_limits = {
+        "free": {"max_users": 5, "max_campaigns": 10},
+        "starter": {"max_users": 10, "max_campaigns": 50},
+        "professional": {"max_users": 25, "max_campaigns": 200},
+        "enterprise": {"max_users": 100, "max_campaigns": 1000},
+    }
+
+    limits = plan_limits[plan]
+    tenant.plan = plan
+    tenant.max_users = limits["max_users"]
+    tenant.max_campaigns = limits["max_campaigns"]
+
+    await db.commit()
+    await db.refresh(tenant)
+
+    logger.info(f"Tenant plan updated: {tenant.slug} -> {plan}")
+
+    return APIResponse(
+        success=True,
+        data=TenantResponse(
+            id=tenant.id,
+            name=tenant.name,
+            slug=tenant.slug,
+            domain=tenant.domain,
+            plan=tenant.plan,
+            plan_expires_at=tenant.plan_expires_at,
+            max_users=tenant.max_users,
+            max_campaigns=tenant.max_campaigns,
+            settings=tenant.settings or {},
+            feature_flags=tenant.feature_flags or {},
+            created_at=tenant.created_at,
+            updated_at=tenant.updated_at,
+        ),
+        message=f"Plan updated to {plan}",
+    )
+
+
+@router.patch("/{tenant_id}/features", response_model=APIResponse[TenantResponse])
+async def update_tenant_features(
+    request: Request,
+    tenant_id: int,
+    feature_flags: dict,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Update tenant feature flags.
+    Requires admin role.
+    """
+    require_admin(request)
+
+    result = await db.execute(
+        select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
+    )
+    tenant = result.scalar_one_or_none()
+
+    if not tenant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    # Merge feature flags
+    current_flags = tenant.feature_flags or {}
+    current_flags.update(feature_flags)
+    tenant.feature_flags = current_flags
+
+    await db.commit()
+    await db.refresh(tenant)
+
+    logger.info(f"Tenant features updated: {tenant.slug}")
+
+    return APIResponse(
+        success=True,
+        data=TenantResponse(
+            id=tenant.id,
+            name=tenant.name,
+            slug=tenant.slug,
+            domain=tenant.domain,
+            plan=tenant.plan,
+            plan_expires_at=tenant.plan_expires_at,
+            max_users=tenant.max_users,
+            max_campaigns=tenant.max_campaigns,
+            settings=tenant.settings or {},
+            feature_flags=tenant.feature_flags or {},
+            created_at=tenant.created_at,
+            updated_at=tenant.updated_at,
+        ),
+        message="Feature flags updated",
+    )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ const Assets = lazy(() => import('./views/Assets'))
 const Rules = lazy(() => import('./views/Rules'))
 const WhatsApp = lazy(() => import('./views/WhatsApp'))
 const Settings = lazy(() => import('./views/Settings'))
+const Tenants = lazy(() => import('./views/Tenants'))
 
 function App() {
   return (
@@ -94,6 +95,14 @@ function App() {
               element={
                 <Suspense fallback={<LoadingSpinner />}>
                   <Settings />
+                </Suspense>
+              }
+            />
+            <Route
+              path="tenants"
+              element={
+                <Suspense fallback={<LoadingSpinner />}>
+                  <Tenants />
                 </Suspense>
               }
             />

--- a/frontend/src/views/DashboardLayout.tsx
+++ b/frontend/src/views/DashboardLayout.tsx
@@ -16,6 +16,7 @@ import {
   BookOpenIcon,
   ChatBubbleLeftRightIcon,
   Squares2X2Icon,
+  BuildingOffice2Icon,
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import LearningHub from '@/components/guide/LearningHub'
@@ -103,8 +104,20 @@ export default function DashboardLayout() {
             })}
           </nav>
 
-          {/* Settings at bottom */}
-          <div className="border-t p-4">
+          {/* Admin & Settings at bottom */}
+          <div className="border-t p-4 space-y-1">
+            <NavLink
+              to="/tenants"
+              className={cn(
+                'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200',
+                location.pathname === '/tenants'
+                  ? 'bg-gradient-stratum text-white shadow-glow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+              )}
+            >
+              <BuildingOffice2Icon className="h-5 w-5" />
+              {t('nav.tenants')}
+            </NavLink>
             <NavLink
               to="/settings"
               className={cn(

--- a/frontend/src/views/Tenants.tsx
+++ b/frontend/src/views/Tenants.tsx
@@ -1,0 +1,868 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Building2,
+  Plus,
+  Search,
+  Edit,
+  Trash2,
+  Users,
+  Crown,
+  ChevronDown,
+  MoreHorizontal,
+  Check,
+  X,
+  AlertTriangle,
+  Calendar,
+  Settings,
+  Shield,
+  RefreshCw,
+  Filter,
+  Globe,
+  Zap,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+// Types
+interface Tenant {
+  id: number
+  name: string
+  slug: string
+  domain: string | null
+  plan: 'free' | 'starter' | 'professional' | 'enterprise'
+  plan_expires_at: string | null
+  max_users: number
+  max_campaigns: number
+  settings: Record<string, unknown>
+  feature_flags: Record<string, boolean>
+  created_at: string
+  updated_at: string
+  user_count?: number
+}
+
+interface TenantFormData {
+  name: string
+  slug: string
+  domain: string
+  plan: 'free' | 'starter' | 'professional' | 'enterprise'
+}
+
+// Mock data for demonstration
+const mockTenants: Tenant[] = [
+  {
+    id: 1,
+    name: 'Acme Corporation',
+    slug: 'acme-corp',
+    domain: 'acme.stratum.ai',
+    plan: 'enterprise',
+    plan_expires_at: '2025-12-31T00:00:00Z',
+    max_users: 100,
+    max_campaigns: 1000,
+    settings: {},
+    feature_flags: { advanced_analytics: true, ai_insights: true, white_label: true },
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-11-20T15:30:00Z',
+    user_count: 45,
+  },
+  {
+    id: 2,
+    name: 'TechStart Inc',
+    slug: 'techstart',
+    domain: null,
+    plan: 'professional',
+    plan_expires_at: '2025-06-30T00:00:00Z',
+    max_users: 25,
+    max_campaigns: 200,
+    settings: {},
+    feature_flags: { advanced_analytics: true, ai_insights: true, white_label: false },
+    created_at: '2024-03-22T08:00:00Z',
+    updated_at: '2024-10-15T12:00:00Z',
+    user_count: 12,
+  },
+  {
+    id: 3,
+    name: 'Marketing Pro',
+    slug: 'marketing-pro',
+    domain: 'marketingpro.stratum.ai',
+    plan: 'starter',
+    plan_expires_at: '2025-03-15T00:00:00Z',
+    max_users: 10,
+    max_campaigns: 50,
+    settings: {},
+    feature_flags: { advanced_analytics: false, ai_insights: true, white_label: false },
+    created_at: '2024-05-10T14:00:00Z',
+    updated_at: '2024-11-01T09:00:00Z',
+    user_count: 8,
+  },
+  {
+    id: 4,
+    name: 'Digital Bloom',
+    slug: 'digital-bloom',
+    domain: null,
+    plan: 'free',
+    plan_expires_at: null,
+    max_users: 5,
+    max_campaigns: 10,
+    settings: {},
+    feature_flags: { advanced_analytics: false, ai_insights: false, white_label: false },
+    created_at: '2024-08-01T11:00:00Z',
+    updated_at: '2024-08-01T11:00:00Z',
+    user_count: 2,
+  },
+]
+
+const planConfig = {
+  free: { color: 'bg-gray-500', label: 'Free', limits: { users: 5, campaigns: 10 } },
+  starter: { color: 'bg-blue-500', label: 'Starter', limits: { users: 10, campaigns: 50 } },
+  professional: { color: 'bg-purple-500', label: 'Professional', limits: { users: 25, campaigns: 200 } },
+  enterprise: { color: 'bg-amber-500', label: 'Enterprise', limits: { users: 100, campaigns: 1000 } },
+}
+
+const featureFlags = [
+  { key: 'advanced_analytics', label: 'Advanced Analytics', description: 'Deep dive analytics and custom reports' },
+  { key: 'ai_insights', label: 'AI Insights', description: 'AI-powered campaign recommendations' },
+  { key: 'white_label', label: 'White Label', description: 'Custom branding and domain' },
+  { key: 'api_access', label: 'API Access', description: 'Full REST API access' },
+  { key: 'sso', label: 'Single Sign-On', description: 'SAML/OAuth SSO integration' },
+  { key: 'audit_logs', label: 'Audit Logs', description: 'Detailed activity logging' },
+]
+
+export function Tenants() {
+  const { t } = useTranslation()
+  const [tenants, setTenants] = useState<Tenant[]>(mockTenants)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [planFilter, setPlanFilter] = useState<string>('all')
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [showEditModal, setShowEditModal] = useState(false)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [showFeaturesModal, setShowFeaturesModal] = useState(false)
+  const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [sortBy, setSortBy] = useState<'name' | 'created_at' | 'user_count'>('name')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+
+  // Filter and sort tenants
+  const filteredTenants = useMemo(() => {
+    let result = [...tenants]
+
+    // Apply search filter
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase()
+      result = result.filter(
+        (t) =>
+          t.name.toLowerCase().includes(query) ||
+          t.slug.toLowerCase().includes(query) ||
+          t.domain?.toLowerCase().includes(query)
+      )
+    }
+
+    // Apply plan filter
+    if (planFilter !== 'all') {
+      result = result.filter((t) => t.plan === planFilter)
+    }
+
+    // Apply sorting
+    result.sort((a, b) => {
+      let comparison = 0
+      if (sortBy === 'name') {
+        comparison = a.name.localeCompare(b.name)
+      } else if (sortBy === 'created_at') {
+        comparison = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+      } else if (sortBy === 'user_count') {
+        comparison = (a.user_count || 0) - (b.user_count || 0)
+      }
+      return sortOrder === 'asc' ? comparison : -comparison
+    })
+
+    return result
+  }, [tenants, searchQuery, planFilter, sortBy, sortOrder])
+
+  // Stats
+  const stats = useMemo(() => {
+    return {
+      total: tenants.length,
+      enterprise: tenants.filter((t) => t.plan === 'enterprise').length,
+      professional: tenants.filter((t) => t.plan === 'professional').length,
+      starter: tenants.filter((t) => t.plan === 'starter').length,
+      free: tenants.filter((t) => t.plan === 'free').length,
+      totalUsers: tenants.reduce((sum, t) => sum + (t.user_count || 0), 0),
+    }
+  }, [tenants])
+
+  const handleCreateTenant = (data: TenantFormData) => {
+    const newTenant: Tenant = {
+      id: Date.now(),
+      ...data,
+      plan_expires_at: data.plan === 'free' ? null : new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+      max_users: planConfig[data.plan].limits.users,
+      max_campaigns: planConfig[data.plan].limits.campaigns,
+      settings: {},
+      feature_flags: {},
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      user_count: 0,
+    }
+    setTenants([...tenants, newTenant])
+    setShowCreateModal(false)
+  }
+
+  const handleUpdateTenant = (data: TenantFormData) => {
+    if (!selectedTenant) return
+    setTenants(
+      tenants.map((t) =>
+        t.id === selectedTenant.id
+          ? {
+              ...t,
+              ...data,
+              max_users: planConfig[data.plan].limits.users,
+              max_campaigns: planConfig[data.plan].limits.campaigns,
+              updated_at: new Date().toISOString(),
+            }
+          : t
+      )
+    )
+    setShowEditModal(false)
+    setSelectedTenant(null)
+  }
+
+  const handleDeleteTenant = () => {
+    if (!selectedTenant) return
+    setTenants(tenants.filter((t) => t.id !== selectedTenant.id))
+    setShowDeleteModal(false)
+    setSelectedTenant(null)
+  }
+
+  const handleUpdateFeatures = (features: Record<string, boolean>) => {
+    if (!selectedTenant) return
+    setTenants(
+      tenants.map((t) =>
+        t.id === selectedTenant.id
+          ? { ...t, feature_flags: features, updated_at: new Date().toISOString() }
+          : t
+      )
+    )
+    setShowFeaturesModal(false)
+    setSelectedTenant(null)
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Building2 className="h-7 w-7 text-primary" />
+            Tenant Management
+          </h1>
+          <p className="text-muted-foreground">Manage organizations and their subscriptions</p>
+        </div>
+        <button
+          onClick={() => setShowCreateModal(true)}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Add Tenant
+        </button>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
+        <StatsCard icon={Building2} label="Total Tenants" value={stats.total} />
+        <StatsCard icon={Crown} label="Enterprise" value={stats.enterprise} color="amber" />
+        <StatsCard icon={Zap} label="Professional" value={stats.professional} color="purple" />
+        <StatsCard icon={Shield} label="Starter" value={stats.starter} color="blue" />
+        <StatsCard icon={Globe} label="Free" value={stats.free} color="gray" />
+        <StatsCard icon={Users} label="Total Users" value={stats.totalUsers} color="green" />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-4 items-center">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search tenants by name, slug, or domain..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4 text-muted-foreground" />
+          <select
+            value={planFilter}
+            onChange={(e) => setPlanFilter(e.target.value)}
+            className="px-3 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+          >
+            <option value="all">All Plans</option>
+            <option value="enterprise">Enterprise</option>
+            <option value="professional">Professional</option>
+            <option value="starter">Starter</option>
+            <option value="free">Free</option>
+          </select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
+            className="px-3 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+          >
+            <option value="name">Sort by Name</option>
+            <option value="created_at">Sort by Created</option>
+            <option value="user_count">Sort by Users</option>
+          </select>
+          <button
+            onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
+            className="p-2 rounded-lg border hover:bg-muted transition-colors"
+          >
+            <ChevronDown className={cn('h-4 w-4 transition-transform', sortOrder === 'asc' && 'rotate-180')} />
+          </button>
+        </div>
+      </div>
+
+      {/* Tenants Table */}
+      <div className="rounded-xl border bg-card overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="px-4 py-3 text-left text-sm font-medium">Organization</th>
+              <th className="px-4 py-3 text-left text-sm font-medium">Plan</th>
+              <th className="px-4 py-3 text-left text-sm font-medium">Users</th>
+              <th className="px-4 py-3 text-left text-sm font-medium">Features</th>
+              <th className="px-4 py-3 text-left text-sm font-medium">Created</th>
+              <th className="px-4 py-3 text-right text-sm font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {filteredTenants.map((tenant) => (
+              <TenantRow
+                key={tenant.id}
+                tenant={tenant}
+                onEdit={() => {
+                  setSelectedTenant(tenant)
+                  setShowEditModal(true)
+                }}
+                onDelete={() => {
+                  setSelectedTenant(tenant)
+                  setShowDeleteModal(true)
+                }}
+                onManageFeatures={() => {
+                  setSelectedTenant(tenant)
+                  setShowFeaturesModal(true)
+                }}
+              />
+            ))}
+            {filteredTenants.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-muted-foreground">
+                  No tenants found matching your criteria
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Create Modal */}
+      {showCreateModal && (
+        <TenantFormModal
+          title="Create New Tenant"
+          onClose={() => setShowCreateModal(false)}
+          onSubmit={handleCreateTenant}
+        />
+      )}
+
+      {/* Edit Modal */}
+      {showEditModal && selectedTenant && (
+        <TenantFormModal
+          title="Edit Tenant"
+          tenant={selectedTenant}
+          onClose={() => {
+            setShowEditModal(false)
+            setSelectedTenant(null)
+          }}
+          onSubmit={handleUpdateTenant}
+        />
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {showDeleteModal && selectedTenant && (
+        <DeleteConfirmModal
+          tenant={selectedTenant}
+          onClose={() => {
+            setShowDeleteModal(false)
+            setSelectedTenant(null)
+          }}
+          onConfirm={handleDeleteTenant}
+        />
+      )}
+
+      {/* Features Modal */}
+      {showFeaturesModal && selectedTenant && (
+        <FeaturesModal
+          tenant={selectedTenant}
+          onClose={() => {
+            setShowFeaturesModal(false)
+            setSelectedTenant(null)
+          }}
+          onSave={handleUpdateFeatures}
+        />
+      )}
+    </div>
+  )
+}
+
+// Stats Card Component
+function StatsCard({
+  icon: Icon,
+  label,
+  value,
+  color = 'primary',
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  label: string
+  value: number
+  color?: string
+}) {
+  const colorClasses: Record<string, string> = {
+    primary: 'bg-primary/10 text-primary',
+    amber: 'bg-amber-500/10 text-amber-500',
+    purple: 'bg-purple-500/10 text-purple-500',
+    blue: 'bg-blue-500/10 text-blue-500',
+    gray: 'bg-gray-500/10 text-gray-500',
+    green: 'bg-green-500/10 text-green-500',
+  }
+
+  return (
+    <div className="p-4 rounded-xl border bg-card">
+      <div className="flex items-center gap-3">
+        <div className={cn('p-2 rounded-lg', colorClasses[color])}>
+          <Icon className="h-5 w-5" />
+        </div>
+        <div>
+          <p className="text-2xl font-bold">{value}</p>
+          <p className="text-xs text-muted-foreground">{label}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Tenant Row Component
+function TenantRow({
+  tenant,
+  onEdit,
+  onDelete,
+  onManageFeatures,
+}: {
+  tenant: Tenant
+  onEdit: () => void
+  onDelete: () => void
+  onManageFeatures: () => void
+}) {
+  const [showMenu, setShowMenu] = useState(false)
+  const plan = planConfig[tenant.plan]
+  const enabledFeatures = Object.values(tenant.feature_flags).filter(Boolean).length
+
+  return (
+    <tr className="hover:bg-muted/30 transition-colors">
+      <td className="px-4 py-4">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary font-semibold">
+            {tenant.name.charAt(0).toUpperCase()}
+          </div>
+          <div>
+            <p className="font-medium">{tenant.name}</p>
+            <p className="text-sm text-muted-foreground">{tenant.slug}</p>
+            {tenant.domain && <p className="text-xs text-primary">{tenant.domain}</p>}
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-4">
+        <span className={cn('px-2 py-1 rounded-full text-xs font-medium text-white', plan.color)}>
+          {plan.label}
+        </span>
+        {tenant.plan_expires_at && (
+          <p className="text-xs text-muted-foreground mt-1">
+            Expires: {new Date(tenant.plan_expires_at).toLocaleDateString()}
+          </p>
+        )}
+      </td>
+      <td className="px-4 py-4">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4 text-muted-foreground" />
+          <span>
+            {tenant.user_count || 0} / {tenant.max_users}
+          </span>
+        </div>
+        <div className="w-24 h-1.5 bg-muted rounded-full mt-1">
+          <div
+            className="h-full bg-primary rounded-full"
+            style={{ width: `${Math.min(100, ((tenant.user_count || 0) / tenant.max_users) * 100)}%` }}
+          />
+        </div>
+      </td>
+      <td className="px-4 py-4">
+        <button onClick={onManageFeatures} className="flex items-center gap-2 text-sm hover:text-primary transition-colors">
+          <Zap className="h-4 w-4" />
+          {enabledFeatures} enabled
+        </button>
+      </td>
+      <td className="px-4 py-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Calendar className="h-4 w-4" />
+          {new Date(tenant.created_at).toLocaleDateString()}
+        </div>
+      </td>
+      <td className="px-4 py-4 text-right">
+        <div className="relative inline-block">
+          <button
+            onClick={() => setShowMenu(!showMenu)}
+            className="p-2 rounded-lg hover:bg-muted transition-colors"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </button>
+          {showMenu && (
+            <>
+              <div className="fixed inset-0 z-10" onClick={() => setShowMenu(false)} />
+              <div className="absolute right-0 top-full mt-1 w-48 rounded-lg border bg-card shadow-lg z-20">
+                <button
+                  onClick={() => {
+                    setShowMenu(false)
+                    onEdit()
+                  }}
+                  className="w-full flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted transition-colors"
+                >
+                  <Edit className="h-4 w-4" />
+                  Edit Tenant
+                </button>
+                <button
+                  onClick={() => {
+                    setShowMenu(false)
+                    onManageFeatures()
+                  }}
+                  className="w-full flex items-center gap-2 px-4 py-2 text-sm hover:bg-muted transition-colors"
+                >
+                  <Settings className="h-4 w-4" />
+                  Manage Features
+                </button>
+                <hr className="my-1" />
+                <button
+                  onClick={() => {
+                    setShowMenu(false)
+                    onDelete()
+                  }}
+                  className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-500 hover:bg-red-500/10 transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete Tenant
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+// Tenant Form Modal
+function TenantFormModal({
+  title,
+  tenant,
+  onClose,
+  onSubmit,
+}: {
+  title: string
+  tenant?: Tenant
+  onClose: () => void
+  onSubmit: (data: TenantFormData) => void
+}) {
+  const [formData, setFormData] = useState<TenantFormData>({
+    name: tenant?.name || '',
+    slug: tenant?.slug || '',
+    domain: tenant?.domain || '',
+    plan: tenant?.plan || 'free',
+  })
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const generateSlug = (name: string) => {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+  }
+
+  const handleNameChange = (name: string) => {
+    setFormData({
+      ...formData,
+      name,
+      slug: tenant ? formData.slug : generateSlug(name),
+    })
+  }
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {}
+    if (!formData.name.trim()) newErrors.name = 'Name is required'
+    if (!formData.slug.trim()) newErrors.slug = 'Slug is required'
+    if (formData.slug && !/^[a-z0-9-]+$/.test(formData.slug)) {
+      newErrors.slug = 'Slug can only contain lowercase letters, numbers, and hyphens'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (validate()) {
+      onSubmit(formData)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-lg bg-card rounded-xl shadow-xl border">
+        <div className="flex items-center justify-between p-4 border-b">
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <button onClick={onClose} className="p-2 rounded-lg hover:bg-muted transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Organization Name *</label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              className={cn(
+                'w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary/20',
+                errors.name && 'border-red-500'
+              )}
+              placeholder="Acme Corporation"
+            />
+            {errors.name && <p className="text-xs text-red-500 mt-1">{errors.name}</p>}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Slug *</label>
+            <input
+              type="text"
+              value={formData.slug}
+              onChange={(e) => setFormData({ ...formData, slug: e.target.value.toLowerCase() })}
+              className={cn(
+                'w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary/20',
+                errors.slug && 'border-red-500'
+              )}
+              placeholder="acme-corp"
+            />
+            {errors.slug && <p className="text-xs text-red-500 mt-1">{errors.slug}</p>}
+            <p className="text-xs text-muted-foreground mt-1">Used in URLs: {formData.slug || 'slug'}.stratum.ai</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Custom Domain</label>
+            <input
+              type="text"
+              value={formData.domain}
+              onChange={(e) => setFormData({ ...formData, domain: e.target.value })}
+              className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="dashboard.company.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">Subscription Plan</label>
+            <div className="grid grid-cols-2 gap-2">
+              {(Object.entries(planConfig) as [keyof typeof planConfig, typeof planConfig.free][]).map(
+                ([key, config]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setFormData({ ...formData, plan: key })}
+                    className={cn(
+                      'p-3 rounded-lg border text-left transition-colors',
+                      formData.plan === key
+                        ? 'border-primary bg-primary/10'
+                        : 'hover:bg-muted'
+                    )}
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className={cn('w-2 h-2 rounded-full', config.color)} />
+                      <span className="font-medium">{config.label}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {config.limits.users} users, {config.limits.campaigns} campaigns
+                    </p>
+                  </button>
+                )
+              )}
+            </div>
+          </div>
+
+          <div className="flex gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 rounded-lg border hover:bg-muted transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="flex-1 px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              {tenant ? 'Save Changes' : 'Create Tenant'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+// Delete Confirmation Modal
+function DeleteConfirmModal({
+  tenant,
+  onClose,
+  onConfirm,
+}: {
+  tenant: Tenant
+  onClose: () => void
+  onConfirm: () => void
+}) {
+  const [confirmText, setConfirmText] = useState('')
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md bg-card rounded-xl shadow-xl border">
+        <div className="p-6 text-center">
+          <div className="w-12 h-12 rounded-full bg-red-500/10 flex items-center justify-center mx-auto mb-4">
+            <AlertTriangle className="h-6 w-6 text-red-500" />
+          </div>
+          <h2 className="text-lg font-semibold mb-2">Delete Tenant</h2>
+          <p className="text-muted-foreground mb-4">
+            Are you sure you want to delete <strong>{tenant.name}</strong>? This action cannot be undone and will delete
+            all associated data.
+          </p>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1 text-left">
+              Type "{tenant.slug}" to confirm
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              className="w-full px-4 py-2 rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-red-500/20"
+              placeholder={tenant.slug}
+            />
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-2 rounded-lg border hover:bg-muted transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onConfirm}
+              disabled={confirmText !== tenant.slug}
+              className="flex-1 px-4 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Delete Tenant
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Features Modal
+function FeaturesModal({
+  tenant,
+  onClose,
+  onSave,
+}: {
+  tenant: Tenant
+  onClose: () => void
+  onSave: (features: Record<string, boolean>) => void
+}) {
+  const [features, setFeatures] = useState<Record<string, boolean>>(
+    featureFlags.reduce(
+      (acc, flag) => ({
+        ...acc,
+        [flag.key]: tenant.feature_flags[flag.key] || false,
+      }),
+      {}
+    )
+  )
+
+  const toggleFeature = (key: string) => {
+    setFeatures({ ...features, [key]: !features[key] })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-lg bg-card rounded-xl shadow-xl border">
+        <div className="flex items-center justify-between p-4 border-b">
+          <div>
+            <h2 className="text-lg font-semibold">Feature Flags</h2>
+            <p className="text-sm text-muted-foreground">{tenant.name}</p>
+          </div>
+          <button onClick={onClose} className="p-2 rounded-lg hover:bg-muted transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3 max-h-96 overflow-y-auto">
+          {featureFlags.map((flag) => (
+            <div
+              key={flag.key}
+              className="flex items-center justify-between p-4 rounded-lg border hover:bg-muted/30 transition-colors"
+            >
+              <div>
+                <p className="font-medium">{flag.label}</p>
+                <p className="text-sm text-muted-foreground">{flag.description}</p>
+              </div>
+              <button
+                onClick={() => toggleFeature(flag.key)}
+                className={cn(
+                  'relative w-12 h-6 rounded-full transition-colors',
+                  features[flag.key] ? 'bg-primary' : 'bg-muted'
+                )}
+              >
+                <span
+                  className={cn(
+                    'absolute top-1 w-4 h-4 bg-white rounded-full transition-transform',
+                    features[flag.key] ? 'translate-x-7' : 'translate-x-1'
+                  )}
+                />
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-3 p-4 border-t">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 rounded-lg border hover:bg-muted transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onSave(features)}
+            className="flex-1 px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Save Features
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Tenants


### PR DESCRIPTION
Backend:
- Create /api/v1/tenants endpoint with full CRUD operations
- Add list, get, create, update, delete tenant endpoints
- Add plan management endpoint for subscription changes
- Add feature flags management endpoint
- Include tenant user count statistics
- Register tenants router in API configuration

Frontend:
- Create Tenants.tsx management page with:
  - Stats cards for tenant overview
  - Searchable and filterable tenant table
  - Create/Edit tenant modal with plan selection
  - Delete confirmation with slug verification
  - Feature flags management modal
  - Sorting by name, created date, or user count
- Add Tenants route to App.tsx
- Add Tenants navigation link in sidebar