### PR TITLE
feat: add ML training data upload via web interface

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -20,6 +20,7 @@ from app.api.v1.endpoints import (
     whatsapp,
     tenants,
     linkedin,
+    ml_training,
 )
 
 api_router = APIRouter()
@@ -106,4 +107,11 @@ api_router.include_router(
     linkedin.router,
     prefix="/linkedin",
     tags=["LinkedIn Ads"],
+)
+
+# ML Training & Data Upload
+api_router.include_router(
+    ml_training.router,
+    prefix="/ml",
+    tags=["ML Training"],
 )

--- a/backend/app/api/v1/endpoints/ml_training.py
+++ b/backend/app/api/v1/endpoints/ml_training.py
@@ -1,0 +1,332 @@
+# =============================================================================
+# Stratum AI - ML Training API Endpoints
+# =============================================================================
+"""
+API endpoints for uploading training data and managing ML models.
+"""
+
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.db.session import get_async_session
+from app.ml.data_loader import TrainingDataLoader
+from app.ml.train import ModelTrainer
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+# =============================================================================
+# Schemas
+# =============================================================================
+class TrainingResponse(BaseModel):
+    """Response for training operations."""
+    success: bool
+    message: str
+    models_trained: List[str]
+    metrics: dict
+    training_time_seconds: float
+
+
+class DataUploadResponse(BaseModel):
+    """Response for data upload operations."""
+    success: bool
+    message: str
+    rows_processed: int
+    columns_detected: List[str]
+    campaigns_created: int
+    metrics_created: int
+
+
+class ModelInfo(BaseModel):
+    """Information about a trained model."""
+    name: str
+    version: str
+    created_at: str
+    metrics: dict
+    features: List[str]
+
+
+class ModelsListResponse(BaseModel):
+    """Response listing all available models."""
+    models: List[ModelInfo]
+    models_path: str
+
+
+class GenerateSampleRequest(BaseModel):
+    """Request to generate sample training data."""
+    num_campaigns: int = 50
+    days_per_campaign: int = 30
+    platforms: Optional[List[str]] = None
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+@router.post("/upload", response_model=DataUploadResponse)
+async def upload_training_data(
+    file: UploadFile = File(...),
+    platform: str = Query("meta", description="Ad platform (meta, google, tiktok, snapchat, linkedin)"),
+    dataset_format: str = Query("generic", description="Dataset format hint (generic, facebook_kaggle, google_kaggle)"),
+    train_after_upload: bool = Query(False, description="Automatically train models after upload"),
+):
+    """
+    Upload CSV training data.
+
+    Supported formats:
+    - Facebook/Meta Ads CSV (Kaggle)
+    - Google Ads CSV (Kaggle)
+    - Generic CSV with spend/impressions/clicks/conversions/revenue columns
+
+    The system auto-detects column mappings based on column names.
+    """
+    if not file.filename.endswith(".csv"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only CSV files are supported",
+        )
+
+    # Save uploaded file temporarily
+    try:
+        with NamedTemporaryFile(delete=False, suffix=".csv") as tmp:
+            shutil.copyfileobj(file.file, tmp)
+            tmp_path = tmp.name
+
+        # Load and process data
+        loader = TrainingDataLoader()
+        df = loader.load_csv_to_dataframe(tmp_path, dataset_format)
+
+        # Save processed data for training
+        data_dir = Path(settings.ml_models_path).parent / "training_data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = data_dir / f"training_data_{timestamp}.csv"
+        df.to_csv(output_path, index=False)
+
+        result = {
+            "success": True,
+            "message": f"Data uploaded and processed successfully. Saved to {output_path}",
+            "rows_processed": len(df),
+            "columns_detected": list(df.columns),
+            "campaigns_created": df["external_id"].nunique() if "external_id" in df.columns else 0,
+            "metrics_created": len(df),
+        }
+
+        # Train models if requested
+        if train_after_upload:
+            trainer = ModelTrainer(settings.ml_models_path)
+            trainer.train_all(df)
+            result["message"] += " Models trained successfully."
+
+        return DataUploadResponse(**result)
+
+    except Exception as e:
+        logger.error("upload_training_data_failed", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to process uploaded file: {str(e)}",
+        )
+
+    finally:
+        # Cleanup temp file
+        if "tmp_path" in locals():
+            os.unlink(tmp_path)
+
+
+@router.post("/train", response_model=TrainingResponse)
+async def train_models(
+    data_file: Optional[str] = Query(None, description="Path to training data CSV (uses latest if not specified)"),
+    use_sample_data: bool = Query(False, description="Use generated sample data instead of uploaded data"),
+    num_campaigns: int = Query(100, description="Number of campaigns for sample data"),
+    days: int = Query(30, description="Days per campaign for sample data"),
+):
+    """
+    Train ML models from uploaded data or sample data.
+
+    Models trained:
+    - roas_predictor: Predicts ROAS from campaign features
+    - conversion_predictor: Predicts conversions
+    - budget_impact: Predicts revenue changes from budget changes
+    """
+    import time
+    start_time = time.time()
+
+    try:
+        if use_sample_data:
+            # Generate sample data
+            df = TrainingDataLoader.generate_sample_data(
+                num_campaigns=num_campaigns,
+                days_per_campaign=days,
+            )
+            logger.info("using_sample_data", rows=len(df))
+        elif data_file:
+            # Use specified file
+            loader = TrainingDataLoader()
+            df = loader.load_csv_to_dataframe(data_file)
+        else:
+            # Find latest uploaded data
+            data_dir = Path(settings.ml_models_path).parent / "training_data"
+            if not data_dir.exists():
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="No training data found. Upload data first or use sample data.",
+                )
+
+            csv_files = sorted(data_dir.glob("*.csv"), key=os.path.getmtime, reverse=True)
+            if not csv_files:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="No training data found. Upload data first or use sample data.",
+                )
+
+            loader = TrainingDataLoader()
+            df = loader.load_csv_to_dataframe(str(csv_files[0]))
+            logger.info("using_latest_data", file=str(csv_files[0]), rows=len(df))
+
+        # Train models
+        trainer = ModelTrainer(settings.ml_models_path)
+        results = trainer.train_all(df)
+
+        elapsed = time.time() - start_time
+
+        return TrainingResponse(
+            success=True,
+            message=f"Successfully trained {len(results)} models",
+            models_trained=list(results.keys()),
+            metrics=results,
+            training_time_seconds=round(elapsed, 2),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("train_models_failed", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Training failed: {str(e)}",
+        )
+
+
+@router.get("/models", response_model=ModelsListResponse)
+async def list_models():
+    """
+    List all trained ML models and their metadata.
+    """
+    import json
+
+    models_path = Path(settings.ml_models_path)
+    models = []
+
+    if models_path.exists():
+        for metadata_file in models_path.glob("*_metadata.json"):
+            try:
+                with open(metadata_file) as f:
+                    metadata = json.load(f)
+                    models.append(ModelInfo(
+                        name=metadata.get("name", metadata_file.stem.replace("_metadata", "")),
+                        version=metadata.get("version", "unknown"),
+                        created_at=metadata.get("created_at", "unknown"),
+                        metrics=metadata.get("metrics", {}),
+                        features=metadata.get("features", []),
+                    ))
+            except Exception as e:
+                logger.warning("failed_to_read_model_metadata", file=str(metadata_file), error=str(e))
+
+    return ModelsListResponse(
+        models=models,
+        models_path=str(models_path),
+    )
+
+
+@router.delete("/models/{model_name}")
+async def delete_model(model_name: str):
+    """
+    Delete a trained model.
+    """
+    models_path = Path(settings.ml_models_path)
+
+    files_to_delete = [
+        models_path / f"{model_name}.pkl",
+        models_path / f"{model_name}_scaler.pkl",
+        models_path / f"{model_name}_metadata.json",
+    ]
+
+    deleted = []
+    for file_path in files_to_delete:
+        if file_path.exists():
+            file_path.unlink()
+            deleted.append(str(file_path))
+
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Model '{model_name}' not found",
+        )
+
+    return {"success": True, "deleted_files": deleted}
+
+
+@router.post("/generate-sample")
+async def generate_sample_data(request: GenerateSampleRequest):
+    """
+    Generate sample training data for testing.
+
+    Returns the generated data as a downloadable CSV.
+    """
+    df = TrainingDataLoader.generate_sample_data(
+        num_campaigns=request.num_campaigns,
+        days_per_campaign=request.days_per_campaign,
+        platforms=request.platforms,
+    )
+
+    # Save to training data directory
+    data_dir = Path(settings.ml_models_path).parent / "training_data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = data_dir / f"sample_data_{timestamp}.csv"
+    df.to_csv(output_path, index=False)
+
+    return {
+        "success": True,
+        "message": f"Generated {len(df)} rows of sample data",
+        "rows": len(df),
+        "campaigns": request.num_campaigns,
+        "days_per_campaign": request.days_per_campaign,
+        "file_path": str(output_path),
+        "columns": list(df.columns),
+    }
+
+
+@router.get("/training-data")
+async def list_training_data():
+    """
+    List available training data files.
+    """
+    data_dir = Path(settings.ml_models_path).parent / "training_data"
+
+    if not data_dir.exists():
+        return {"files": [], "directory": str(data_dir)}
+
+    files = []
+    for csv_file in sorted(data_dir.glob("*.csv"), key=os.path.getmtime, reverse=True):
+        stat = csv_file.stat()
+        files.append({
+            "name": csv_file.name,
+            "path": str(csv_file),
+            "size_bytes": stat.st_size,
+            "modified_at": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+        })
+
+    return {"files": files, "directory": str(data_dir)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ const Rules = lazy(() => import('./views/Rules'))
 const WhatsApp = lazy(() => import('./views/WhatsApp'))
 const Settings = lazy(() => import('./views/Settings'))
 const Tenants = lazy(() => import('./views/Tenants'))
+const MLTraining = lazy(() => import('./views/MLTraining'))
 
 function App() {
   return (
@@ -103,6 +104,14 @@ function App() {
               element={
                 <Suspense fallback={<LoadingSpinner />}>
                   <Tenants />
+                </Suspense>
+              }
+            />
+            <Route
+              path="ml-training"
+              element={
+                <Suspense fallback={<LoadingSpinner />}>
+                  <MLTraining />
                 </Suspense>
               }
             />

--- a/frontend/src/views/DashboardLayout.tsx
+++ b/frontend/src/views/DashboardLayout.tsx
@@ -17,6 +17,7 @@ import {
   ChatBubbleLeftRightIcon,
   Squares2X2Icon,
   BuildingOffice2Icon,
+  CpuChipIcon,
 } from '@heroicons/react/24/outline'
 import { cn } from '@/lib/utils'
 import LearningHub from '@/components/guide/LearningHub'
@@ -117,6 +118,18 @@ export default function DashboardLayout() {
             >
               <BuildingOffice2Icon className="h-5 w-5" />
               {t('nav.tenants')}
+            </NavLink>
+            <NavLink
+              to="/ml-training"
+              className={cn(
+                'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200',
+                location.pathname === '/ml-training'
+                  ? 'bg-gradient-stratum text-white shadow-glow-sm'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+              )}
+            >
+              <CpuChipIcon className="h-5 w-5" />
+              {t('nav.mlTraining')}
             </NavLink>
             <NavLink
               to="/settings"

--- a/frontend/src/views/MLTraining.tsx
+++ b/frontend/src/views/MLTraining.tsx
@@ -1,0 +1,694 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  Upload,
+  Brain,
+  Database,
+  FileSpreadsheet,
+  Play,
+  Trash2,
+  Download,
+  CheckCircle,
+  XCircle,
+  Clock,
+  AlertCircle,
+  RefreshCw,
+  BarChart3,
+  Target,
+  TrendingUp,
+  Cpu,
+  HardDrive,
+  Sparkles,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+// Types
+interface ModelInfo {
+  name: string
+  version: string
+  created_at: string
+  metrics: {
+    r2?: number
+    mae?: number
+    rmse?: number
+    mape?: number
+  }
+  features: string[]
+}
+
+interface TrainingFile {
+  name: string
+  path: string
+  size_bytes: number
+  modified_at: string
+}
+
+interface TrainingResult {
+  success: boolean
+  message: string
+  models_trained: string[]
+  metrics: Record<string, any>
+  training_time_seconds: number
+}
+
+type TabType = 'upload' | 'models' | 'training'
+
+export default function MLTraining() {
+  const [activeTab, setActiveTab] = useState<TabType>('upload')
+  const [models, setModels] = useState<ModelInfo[]>([])
+  const [trainingFiles, setTrainingFiles] = useState<TrainingFile[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isTraining, setIsTraining] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState(0)
+  const [trainingResult, setTrainingResult] = useState<TrainingResult | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Fetch models and training data on mount
+  useEffect(() => {
+    fetchModels()
+    fetchTrainingData()
+  }, [])
+
+  const fetchModels = async () => {
+    try {
+      const response = await fetch('/api/v1/ml/models')
+      const data = await response.json()
+      setModels(data.models || [])
+    } catch (err) {
+      console.error('Failed to fetch models:', err)
+    }
+  }
+
+  const fetchTrainingData = async () => {
+    try {
+      const response = await fetch('/api/v1/ml/training-data')
+      const data = await response.json()
+      setTrainingFiles(data.files || [])
+    } catch (err) {
+      console.error('Failed to fetch training data:', err)
+    }
+  }
+
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    if (!file.name.endsWith('.csv')) {
+      setError('Please upload a CSV file')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    setUploadProgress(0)
+
+    const formData = new FormData()
+    formData.append('file', file)
+
+    try {
+      const response = await fetch('/api/v1/ml/upload?train_after_upload=false', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!response.ok) {
+        throw new Error('Upload failed')
+      }
+
+      const data = await response.json()
+      setUploadProgress(100)
+
+      // Refresh training data list
+      await fetchTrainingData()
+
+      // Show success
+      setError(null)
+      alert(`Successfully uploaded ${data.rows_processed} rows of training data`)
+    } catch (err) {
+      setError('Failed to upload file. Please try again.')
+      console.error('Upload error:', err)
+    } finally {
+      setIsLoading(false)
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+    }
+  }
+
+  const handleGenerateSample = async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/v1/ml/generate-sample', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          num_campaigns: 100,
+          days_per_campaign: 30,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to generate sample data')
+      }
+
+      const data = await response.json()
+      await fetchTrainingData()
+      alert(`Generated ${data.rows} rows of sample training data`)
+    } catch (err) {
+      setError('Failed to generate sample data')
+      console.error('Generate sample error:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleTrainModels = async (useSampleData: boolean = false) => {
+    setIsTraining(true)
+    setTrainingResult(null)
+    setError(null)
+
+    try {
+      const url = useSampleData
+        ? '/api/v1/ml/train?use_sample_data=true&num_campaigns=100&days=30'
+        : '/api/v1/ml/train'
+
+      const response = await fetch(url, { method: 'POST' })
+
+      if (!response.ok) {
+        throw new Error('Training failed')
+      }
+
+      const data = await response.json()
+      setTrainingResult(data)
+      await fetchModels()
+    } catch (err) {
+      setError('Training failed. Please ensure you have uploaded training data.')
+      console.error('Training error:', err)
+    } finally {
+      setIsTraining(false)
+    }
+  }
+
+  const handleDeleteModel = async (modelName: string) => {
+    if (!confirm(`Are you sure you want to delete the ${modelName} model?`)) {
+      return
+    }
+
+    try {
+      const response = await fetch(`/api/v1/ml/models/${modelName}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        throw new Error('Delete failed')
+      }
+
+      await fetchModels()
+    } catch (err) {
+      setError('Failed to delete model')
+      console.error('Delete error:', err)
+    }
+  }
+
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+
+  const getModelIcon = (name: string) => {
+    if (name.includes('roas')) return <TrendingUp className="w-5 h-5" />
+    if (name.includes('conversion')) return <Target className="w-5 h-5" />
+    if (name.includes('budget')) return <BarChart3 className="w-5 h-5" />
+    return <Brain className="w-5 h-5" />
+  }
+
+  const tabs = [
+    { id: 'upload' as TabType, label: 'Upload Data', icon: Upload },
+    { id: 'models' as TabType, label: 'Models', icon: Brain },
+    { id: 'training' as TabType, label: 'Train', icon: Cpu },
+  ]
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            ML Training
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
+            Upload training data and manage ML models
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={cn(
+            "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium",
+            models.length > 0
+              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+              : "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
+          )}>
+            <Cpu className="w-4 h-4" />
+            {models.length} Models Ready
+          </span>
+        </div>
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-center gap-3">
+          <AlertCircle className="w-5 h-5 text-red-500" />
+          <span className="text-red-700 dark:text-red-400">{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="ml-auto text-red-500 hover:text-red-700"
+          >
+            <XCircle className="w-5 h-5" />
+          </button>
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="border-b border-gray-200 dark:border-gray-700">
+        <nav className="flex gap-4">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                "flex items-center gap-2 px-4 py-3 border-b-2 font-medium transition-colors",
+                activeTab === tab.id
+                  ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                  : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400"
+              )}
+            >
+              <tab.icon className="w-5 h-5" />
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Upload Tab */}
+      {activeTab === 'upload' && (
+        <div className="space-y-6">
+          {/* Upload Area */}
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              Upload Training Data
+            </h2>
+
+            <div className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-8 text-center">
+              <input
+                type="file"
+                ref={fileInputRef}
+                onChange={handleFileUpload}
+                accept=".csv"
+                className="hidden"
+              />
+              <FileSpreadsheet className="w-12 h-12 mx-auto text-gray-400 mb-4" />
+              <p className="text-gray-600 dark:text-gray-400 mb-2">
+                Drag and drop your CSV file here, or
+              </p>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isLoading}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                {isLoading ? 'Uploading...' : 'Browse Files'}
+              </button>
+              <p className="text-sm text-gray-500 dark:text-gray-500 mt-4">
+                Supported: CSV files from Kaggle (Facebook Ads, Google Ads) or generic format
+              </p>
+            </div>
+
+            {/* Required Columns */}
+            <div className="mt-6">
+              <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Required CSV Columns:
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {['spend', 'impressions', 'clicks', 'conversions', 'revenue', 'platform', 'date'].map((col) => (
+                  <span
+                    key={col}
+                    className="px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded text-sm text-gray-600 dark:text-gray-400"
+                  >
+                    {col}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Generate Sample Data */}
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              Or Generate Sample Data
+            </h2>
+            <p className="text-gray-500 dark:text-gray-400 mb-4">
+              Generate synthetic training data for testing the ML pipeline
+            </p>
+            <button
+              onClick={handleGenerateSample}
+              disabled={isLoading}
+              className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+            >
+              <Sparkles className="w-5 h-5" />
+              Generate 100 Campaigns (30 days each)
+            </button>
+          </div>
+
+          {/* Training Files List */}
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                Training Data Files
+              </h2>
+              <button
+                onClick={fetchTrainingData}
+                className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+              >
+                <RefreshCw className="w-5 h-5 text-gray-500" />
+              </button>
+            </div>
+
+            {trainingFiles.length === 0 ? (
+              <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+                No training data uploaded yet
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {trainingFiles.map((file) => (
+                  <div
+                    key={file.path}
+                    className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg"
+                  >
+                    <div className="flex items-center gap-3">
+                      <Database className="w-5 h-5 text-blue-500" />
+                      <div>
+                        <p className="font-medium text-gray-900 dark:text-white">
+                          {file.name}
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          {formatBytes(file.size_bytes)} • {formatDate(file.modified_at)}
+                        </p>
+                      </div>
+                    </div>
+                    <CheckCircle className="w-5 h-5 text-green-500" />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Models Tab */}
+      {activeTab === 'models' && (
+        <div className="space-y-6">
+          {models.length === 0 ? (
+            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-12 text-center">
+              <Brain className="w-16 h-16 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                No Models Trained
+              </h3>
+              <p className="text-gray-500 dark:text-gray-400 mb-4">
+                Upload training data and train models to get started
+              </p>
+              <button
+                onClick={() => setActiveTab('training')}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
+                Go to Training
+              </button>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {models.map((model) => (
+                <div
+                  key={model.name}
+                  className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6"
+                >
+                  <div className="flex items-start justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-blue-100 dark:bg-blue-900/30 rounded-lg text-blue-600 dark:text-blue-400">
+                        {getModelIcon(model.name)}
+                      </div>
+                      <div>
+                        <h3 className="font-semibold text-gray-900 dark:text-white">
+                          {model.name.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                        </h3>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          v{model.version}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleDeleteModel(model.name)}
+                      className="p-1.5 hover:bg-red-100 dark:hover:bg-red-900/30 rounded text-gray-400 hover:text-red-500"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+
+                  {/* Metrics */}
+                  <div className="space-y-2 mb-4">
+                    {model.metrics.r2 !== undefined && (
+                      <div className="flex justify-between text-sm">
+                        <span className="text-gray-500 dark:text-gray-400">R² Score</span>
+                        <span className={cn(
+                          "font-medium",
+                          model.metrics.r2 > 0.7 ? "text-green-600" :
+                          model.metrics.r2 > 0.5 ? "text-yellow-600" : "text-red-600"
+                        )}>
+                          {(model.metrics.r2 * 100).toFixed(1)}%
+                        </span>
+                      </div>
+                    )}
+                    {model.metrics.mae !== undefined && (
+                      <div className="flex justify-between text-sm">
+                        <span className="text-gray-500 dark:text-gray-400">MAE</span>
+                        <span className="font-medium text-gray-900 dark:text-white">
+                          {model.metrics.mae.toFixed(3)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Features */}
+                  <div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Features:</p>
+                    <div className="flex flex-wrap gap-1">
+                      {model.features.slice(0, 4).map((feature) => (
+                        <span
+                          key={feature}
+                          className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs text-gray-600 dark:text-gray-400"
+                        >
+                          {feature}
+                        </span>
+                      ))}
+                      {model.features.length > 4 && (
+                        <span className="px-1.5 py-0.5 text-xs text-gray-500">
+                          +{model.features.length - 4} more
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <p className="text-xs text-gray-400 dark:text-gray-500 mt-4">
+                    Created: {formatDate(model.created_at)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Training Tab */}
+      {activeTab === 'training' && (
+        <div className="space-y-6">
+          {/* Training Options */}
+          <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              Train Models
+            </h2>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {/* Train from Uploaded Data */}
+              <div className="p-4 border border-gray-200 dark:border-gray-600 rounded-lg">
+                <div className="flex items-center gap-3 mb-3">
+                  <Database className="w-6 h-6 text-blue-500" />
+                  <h3 className="font-medium text-gray-900 dark:text-white">
+                    Train from Uploaded Data
+                  </h3>
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                  Use your uploaded CSV training data to train models
+                </p>
+                <button
+                  onClick={() => handleTrainModels(false)}
+                  disabled={isTraining || trainingFiles.length === 0}
+                  className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isTraining ? (
+                    <>
+                      <RefreshCw className="w-5 h-5 animate-spin" />
+                      Training...
+                    </>
+                  ) : (
+                    <>
+                      <Play className="w-5 h-5" />
+                      Start Training
+                    </>
+                  )}
+                </button>
+                {trainingFiles.length === 0 && (
+                  <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-2">
+                    Upload training data first
+                  </p>
+                )}
+              </div>
+
+              {/* Train from Sample Data */}
+              <div className="p-4 border border-gray-200 dark:border-gray-600 rounded-lg">
+                <div className="flex items-center gap-3 mb-3">
+                  <Sparkles className="w-6 h-6 text-purple-500" />
+                  <h3 className="font-medium text-gray-900 dark:text-white">
+                    Train from Sample Data
+                  </h3>
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                  Generate synthetic data and train models for testing
+                </p>
+                <button
+                  onClick={() => handleTrainModels(true)}
+                  disabled={isTraining}
+                  className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+                >
+                  {isTraining ? (
+                    <>
+                      <RefreshCw className="w-5 h-5 animate-spin" />
+                      Training...
+                    </>
+                  ) : (
+                    <>
+                      <Play className="w-5 h-5" />
+                      Quick Train
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Training Result */}
+          {trainingResult && (
+            <div className={cn(
+              "rounded-xl border p-6",
+              trainingResult.success
+                ? "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800"
+                : "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800"
+            )}>
+              <div className="flex items-center gap-3 mb-4">
+                {trainingResult.success ? (
+                  <CheckCircle className="w-6 h-6 text-green-500" />
+                ) : (
+                  <XCircle className="w-6 h-6 text-red-500" />
+                )}
+                <h3 className={cn(
+                  "font-semibold",
+                  trainingResult.success ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"
+                )}>
+                  {trainingResult.message}
+                </h3>
+              </div>
+
+              {trainingResult.success && (
+                <>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    Training completed in {trainingResult.training_time_seconds}s
+                  </p>
+
+                  <div className="space-y-3">
+                    {trainingResult.models_trained.map((modelName) => {
+                      const metrics = trainingResult.metrics[modelName] || {}
+                      return (
+                        <div
+                          key={modelName}
+                          className="flex items-center justify-between p-3 bg-white dark:bg-gray-800 rounded-lg"
+                        >
+                          <div className="flex items-center gap-3">
+                            {getModelIcon(modelName)}
+                            <span className="font-medium text-gray-900 dark:text-white">
+                              {modelName}
+                            </span>
+                          </div>
+                          <span className={cn(
+                            "text-sm font-medium",
+                            metrics.r2 > 0.7 ? "text-green-600" :
+                            metrics.r2 > 0.5 ? "text-yellow-600" : "text-red-600"
+                          )}>
+                            R² = {metrics.r2 ? (metrics.r2 * 100).toFixed(1) : 'N/A'}%
+                          </span>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Models Being Trained Info */}
+          <div className="bg-gray-50 dark:bg-gray-800/50 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+            <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+              Models That Will Be Trained
+            </h3>
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="flex items-start gap-3">
+                <TrendingUp className="w-5 h-5 text-blue-500 mt-0.5" />
+                <div>
+                  <h4 className="font-medium text-gray-900 dark:text-white">ROAS Predictor</h4>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Predicts Return on Ad Spend from campaign features
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <Target className="w-5 h-5 text-green-500 mt-0.5" />
+                <div>
+                  <h4 className="font-medium text-gray-900 dark:text-white">Conversion Predictor</h4>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Predicts conversions based on spend and engagement
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <BarChart3 className="w-5 h-5 text-purple-500 mt-0.5" />
+                <div>
+                  <h4 className="font-medium text-gray-900 dark:text-white">Budget Impact</h4>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Predicts revenue changes from budget adjustments
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Backend:
- Add /api/v1/ml/upload endpoint for CSV upload
- Add /api/v1/ml/train endpoint to trigger model training
- Add /api/v1/ml/models endpoint to list trained models
- Add /api/v1/ml/generate-sample for synthetic data
- Add /api/v1/ml/training-data to list uploaded files

Frontend:
- Add MLTraining page with 3 tabs: Upload, Models, Training
- Support drag-and-drop CSV upload
- Display trained models with metrics (R², MAE)
- Add navigation link in sidebar