### PR TITLE
refactor: Enable SIM108 rule (use ternary operator)

### DIFF
--- a/backend/app/analytics/logic/emq_calculation.py
+++ b/backend/app/analytics/logic/emq_calculation.py
@@ -131,10 +131,7 @@ def calculate_event_match_rate(metrics: PlatformMetrics) -> EmqDriverResult:
         # Estimate from pixel/CAPI overlap
         min_events = min(metrics.pixel_events, metrics.capi_events)
         max_events = max(metrics.pixel_events, metrics.capi_events)
-        if max_events > 0:
-            match_rate = (min_events / max_events) * 100
-        else:
-            match_rate = 0.0
+        match_rate = min_events / max_events * 100 if max_events > 0 else 0.0
 
     # Clamp to 0-100
     value = min(100.0, max(0.0, match_rate))

--- a/backend/app/analytics/logic/fatigue.py
+++ b/backend/app/analytics/logic/fatigue.py
@@ -55,10 +55,7 @@ def creative_fatigue(
 
     # Calculate signal drops
     # CTR drop
-    if baseline.ctr > 0.0001:
-        ctr_drop = clamp01((baseline.ctr - today.ctr) / baseline.ctr)
-    else:
-        ctr_drop = 0.0
+    ctr_drop = clamp01((baseline.ctr - today.ctr) / baseline.ctr) if baseline.ctr > 0.0001 else 0.0
 
     # ROAS drop
     if baseline.roas > 0.01:
@@ -67,10 +64,7 @@ def creative_fatigue(
         roas_drop = 0.0
 
     # CPA rise (higher is worse)
-    if baseline.cpa > 0.01:
-        cpa_rise = clamp01((today.cpa - baseline.cpa) / baseline.cpa)
-    else:
-        cpa_rise = 0.0
+    cpa_rise = clamp01((today.cpa - baseline.cpa) / baseline.cpa) if baseline.cpa > 0.01 else 0.0
 
     # Exposure factor (frequency based)
     # frequency 2->5 maps to 0..1
@@ -88,10 +82,7 @@ def creative_fatigue(
     )
 
     # Smooth with EMA to avoid noise
-    if prev_ema is not None:
-        smoothed_fatigue = ema(fatigue, prev_ema, params.ema_alpha)
-    else:
-        smoothed_fatigue = fatigue
+    smoothed_fatigue = ema(fatigue, prev_ema, params.ema_alpha) if prev_ema is not None else fatigue
 
     # Determine state
     if smoothed_fatigue >= params.refresh_threshold:

--- a/backend/app/analytics/logic/scoring.py
+++ b/backend/app/analytics/logic/scoring.py
@@ -84,10 +84,7 @@ def scaling_score(
 
     # Volume penalty (insufficient conversions)
     min_conversions = params.min_conversions
-    if today.conversions > 0:
-        vol_penalty = clamp01(min_conversions / today.conversions)
-    else:
-        vol_penalty = 1.0  # No conversions = max penalty
+    vol_penalty = clamp01(min_conversions / today.conversions) if today.conversions > 0 else 1.0
 
     # Score components (weights tuned for e-commerce ROAS)
     score = 0.0

--- a/backend/app/api/v1/endpoints/cdp.py
+++ b/backend/app/api/v1/endpoints/cdp.py
@@ -1447,10 +1447,7 @@ async def get_event_trends(
     for name in all_names:
         curr = current_names.get(name, 0)
         prev = previous_names.get(name, 0)
-        if prev > 0:
-            trend_pct = ((curr - prev) / prev) * 100
-        else:
-            trend_pct = 100.0 if curr > 0 else 0.0
+        trend_pct = (curr - prev) / prev * 100 if prev > 0 else 100.0 if curr > 0 else 0.0
 
         event_trends.append(
             {

--- a/backend/app/api/v1/endpoints/stripe_webhook.py
+++ b/backend/app/api/v1/endpoints/stripe_webhook.py
@@ -285,10 +285,7 @@ async def handle_subscription_deleted(db: AsyncSession, subscription: dict):
 
     # Get the ended date from subscription
     ended_at = subscription.get("ended_at")
-    if ended_at:
-        ended_datetime = datetime.fromtimestamp(ended_at, tz=UTC)
-    else:
-        ended_datetime = datetime.now(UTC)
+    ended_datetime = datetime.fromtimestamp(ended_at, tz=UTC) if ended_at else datetime.now(UTC)
 
     # Update tenant to free plan with expiry
     await db.execute(

--- a/backend/app/ml/ab_power_analysis.py
+++ b/backend/app/ml/ab_power_analysis.py
@@ -457,10 +457,7 @@ class ABPowerAnalyzer:
 
         # Decision
         if p_value < adjusted_alpha:
-            if p2 > p1:
-                conclusion = "variant_b_wins"
-            else:
-                conclusion = "variant_a_wins"
+            conclusion = "variant_b_wins" if p2 > p1 else "variant_a_wins"
             should_stop = True
         elif total_samples >= planned_samples:
             conclusion = "no_difference"

--- a/backend/app/ml/creative_lifecycle.py
+++ b/backend/app/ml/creative_lifecycle.py
@@ -435,12 +435,7 @@ class CreativeLifecyclePredictor:
         fatigue_needed = self.fatigue_threshold - current_fatigue
 
         # Estimate days (simplified - fatigue increases roughly linearly with CTR decline)
-        if decay_rate > 0:
-            days_estimate = int(
-                fatigue_needed / (decay_rate * 0.3)
-            )  # 0.3 is approximate conversion
-        else:
-            days_estimate = 30
+        days_estimate = int(fatigue_needed / (decay_rate * 0.3)) if decay_rate > 0 else 30
 
         # Cap at reasonable range
         return max(0, min(days_estimate, 60))
@@ -859,10 +854,7 @@ class CreativeClusterAnalyzer:
         # Days to fatigue (when CTR drops to 35% of peak)
         fatigue_threshold = peak_ctr * 0.35
         below_fatigue = np.where(ctr_arr < fatigue_threshold)[0]
-        if len(below_fatigue) > 0:
-            days_to_fatigue = int(below_fatigue[0])
-        else:
-            days_to_fatigue = len(ctr_arr) + 7
+        days_to_fatigue = int(below_fatigue[0]) if len(below_fatigue) > 0 else len(ctr_arr) + 7
 
         # Total lifetime CTR (area under curve, proxy for total value)
         total_ctr = float(np.sum(ctr_arr))

--- a/backend/app/ml/roas_optimizer.py
+++ b/backend/app/ml/roas_optimizer.py
@@ -476,10 +476,7 @@ class ROASOptimizer:
             new_spend = current_spend * mult
 
             # Apply diminishing returns for increases
-            if mult > 1:
-                roas_adjustment = 1 - (mult - 1) * 0.15  # 15% ROAS decline per 100% increase
-            else:
-                roas_adjustment = 1 + (1 - mult) * 0.1  # Slight ROAS improvement with decrease
+            roas_adjustment = 1 - (mult - 1) * 0.15 if mult > 1 else 1 + (1 - mult) * 0.1
 
             predicted_roas = current_roas * roas_adjustment
             predicted_revenue = new_spend * predicted_roas

--- a/backend/app/services/attribution/attribution_service.py
+++ b/backend/app/services/attribution/attribution_service.py
@@ -363,11 +363,7 @@ class AttributionService:
             )
 
         # Update deal with primary attribution (based on model)
-        if model == AttributionModel.FIRST_TOUCH:
-            primary_tp = touchpoints[0]
-        else:
-            # All other models use last touch as primary
-            primary_tp = touchpoints[-1]
+        primary_tp = touchpoints[0] if model == AttributionModel.FIRST_TOUCH else touchpoints[-1]
 
         deal.attributed_touchpoint_id = primary_tp.id
         deal.attributed_campaign_id = primary_tp.campaign_id

--- a/backend/app/services/audience_insights_service.py
+++ b/backend/app/services/audience_insights_service.py
@@ -1015,10 +1015,7 @@ class AudienceDecayPredictor:
         score_90d = current_score * (1 - adjusted_decay * 3)
 
         # Determine time to refresh (when score drops below 50% of current)
-        if adjusted_decay > 0:
-            time_to_refresh = int(0.5 / adjusted_decay * 30)
-        else:
-            time_to_refresh = 365
+        time_to_refresh = int(0.5 / adjusted_decay * 30) if adjusted_decay > 0 else 365
 
         # Identify factors
         factors = []

--- a/backend/app/services/cdp/segment_service.py
+++ b/backend/app/services/cdp/segment_service.py
@@ -111,10 +111,7 @@ class SegmentEvaluator:
             return False, None
 
         # Apply logic
-        if logic == "and":
-            final_match = all(results)
-        else:  # or
-            final_match = any(results)
+        final_match = all(results) if logic == "and" else any(results)
 
         # Calculate average score
         avg_score = sum(scores) / len(scores) if scores else None
@@ -289,15 +286,9 @@ class SegmentEvaluator:
                 else:
                     result = False
             elif op == "in":
-                if isinstance(expected, list):
-                    result = actual in expected
-                else:
-                    result = False
+                result = actual in expected if isinstance(expected, list) else False
             elif op == "not_in":
-                if isinstance(expected, list):
-                    result = actual not in expected
-                else:
-                    result = True
+                result = actual not in expected if isinstance(expected, list) else True
             elif op == "is_null":
                 result = actual is None
             elif op == "is_not_null":

--- a/backend/app/services/embed_widgets/security.py
+++ b/backend/app/services/embed_widgets/security.py
@@ -122,10 +122,7 @@ class EmbedSecurityService:
 
         # Extract hostname from origin
         try:
-            if "://" in origin:
-                hostname = origin.split("://")[1]
-            else:
-                hostname = origin
+            hostname = origin.split("://")[1] if "://" in origin else origin
 
             if ":" in hostname:
                 hostname = hostname.split(":")[0]

--- a/backend/app/services/embed_widgets/token_service.py
+++ b/backend/app/services/embed_widgets/token_service.py
@@ -366,10 +366,7 @@ class EmbedTokenService:
         # Origin format: https://example.com or http://localhost:3000
         try:
             # Remove protocol
-            if "://" in origin:
-                hostname = origin.split("://")[1]
-            else:
-                hostname = origin
+            hostname = origin.split("://")[1] if "://" in origin else origin
 
             # Remove port if present
             if ":" in hostname:

--- a/backend/app/services/emq_measurement_service.py
+++ b/backend/app/services/emq_measurement_service.py
@@ -541,10 +541,7 @@ class RealEMQService:
         Returns:
             Dict with mode recommendation and details
         """
-        if platform:
-            emq_result = self.get_platform_emq(platform)
-        else:
-            emq_result = self.get_aggregate_emq()
+        emq_result = self.get_platform_emq(platform) if platform else self.get_aggregate_emq()
 
         mode, reason = determine_autopilot_mode(emq_result.score)
 

--- a/backend/app/services/pacing/forecasting.py
+++ b/backend/app/services/pacing/forecasting.py
@@ -181,10 +181,7 @@ class ForecastingService:
             EOM forecast with MTD actual and projections
         """
         today = date.today()
-        if month is None:
-            month = today.replace(day=1)
-        else:
-            month = month.replace(day=1)
+        month = today.replace(day=1) if month is None else month.replace(day=1)
 
         # Get MTD actual
         eom = self._get_end_of_month(month)

--- a/ruff.toml
+++ b/ruff.toml
@@ -83,7 +83,6 @@ ignore = [
     "S112",   # try-except-continue (intentional)
     "S608",   # SQL injection (manual review needed - often false positive)
     "SIM102", # Nested if statements (28 violations - readability)
-    "SIM108", # Use ternary operator (22 violations - readability)
     "T20",    # Print statements (allowed in scripts)
     "UP007",  # Use X | Y for Union (keep Optional for clarity)
     "UP038",  # Use X | Y in isinstance (legacy code)


### PR DESCRIPTION
## Summary
Enable SIM108 rule - convert if-else blocks to ternary expressions.

### Files Updated (20 violations fixed)
| Category | Files |
|----------|-------|
| Analytics | `emq_calculation.py`, `fatigue.py`, `scoring.py` |
| API | `cdp.py`, `stripe_webhook.py` |
| ML | `ab_power_analysis.py`, `creative_lifecycle.py`, `roas_optimizer.py` |
| Services | `attribution_service.py`, `segment_service.py`, `audience_insights_service.py`, `emq_measurement_service.py` |
| Embed | `security.py`, `token_service.py` |
| Pacing | `forecasting.py` |

### Example Change
```python
# Before
if condition:
    result = value_a
else:
    result = value_b

# After
result = value_a if condition else value_b
```

## Test plan
- [x] `ruff check backend/` passes
- [x] All ternary conversions preserve logic

:robot: Generated with [Claude Code](https://claude.com/claude-code)