### PR TITLE
feat(launch-readiness): superadmin sequential go-live wizard

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -66,6 +66,7 @@ from app.api.v1.endpoints import (
     embed_widgets,
     audience_sync,
     copilot,
+    launch_readiness,
 )
 
 api_router = APIRouter()
@@ -198,6 +199,13 @@ api_router.include_router(
     superadmin.router,
     prefix="/superadmin",
     tags=["Super Admin"],
+)
+
+# Launch Readiness (Go-Live wizard)
+api_router.include_router(
+    launch_readiness.router,
+    prefix="/superadmin/launch-readiness",
+    tags=["Launch Readiness"],
 )
 
 # Dashboard (Overview metrics, signal health, campaigns, settings)

--- a/backend/app/api/v1/endpoints/launch_readiness.py
+++ b/backend/app/api/v1/endpoints/launch_readiness.py
@@ -1,0 +1,359 @@
+# =============================================================================
+# Stratum AI - Launch Readiness Endpoints
+# =============================================================================
+"""
+Superadmin-only endpoints for the Launch Readiness wizard.
+
+Rules:
+- Phase N+1 is locked until phase N is 100 percent complete.
+- Checking an item is allowed only when its phase is the current phase.
+- Unchecking is always allowed. Unchecking an item in a completed phase
+  re-opens that phase (and naturally relocks later phases).
+- Every state change appends a row to ``launch_readiness_events`` for audit.
+"""
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.launch_readiness_phases import (
+    LAUNCH_READINESS_PHASES,
+    find_item,
+    total_item_count,
+)
+from app.core.logging import get_logger
+from app.db.session import get_async_session
+from app.models import (
+    LaunchReadinessEvent,
+    LaunchReadinessItemState,
+    User,
+    UserRole,
+)
+from app.schemas import APIResponse
+from app.schemas.launch_readiness import (
+    LaunchReadinessEventEntry,
+    LaunchReadinessItem,
+    LaunchReadinessItemUpdate,
+    LaunchReadinessPhase,
+    LaunchReadinessState,
+)
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+# =============================================================================
+# Dependencies
+# =============================================================================
+def require_superadmin(request: Request) -> int:
+    """Verify user has superadmin role. Returns the acting user id."""
+    user_role = getattr(request.state, "role", None)
+    user_id = getattr(request.state, "user_id", None)
+
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    if user_role != UserRole.SUPERADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Superadmin access required",
+        )
+
+    return user_id
+
+
+# =============================================================================
+# State assembly
+# =============================================================================
+async def _load_states_by_key(
+    db: AsyncSession,
+) -> Dict[str, LaunchReadinessItemState]:
+    """Return a {item_key: state_row} map for every persisted item state."""
+    result = await db.execute(select(LaunchReadinessItemState))
+    rows = result.scalars().all()
+    return {row.item_key: row for row in rows}
+
+
+async def _build_state(db: AsyncSession) -> LaunchReadinessState:
+    """Merge the static phase catalog with DB state into the response shape."""
+    states = await _load_states_by_key(db)
+
+    phases: List[LaunchReadinessPhase] = []
+    current_phase_number: Optional[int] = None
+    overall_completed = 0
+
+    for phase_def in LAUNCH_READINESS_PHASES:
+        phase_items: List[LaunchReadinessItem] = []
+        completed = 0
+
+        for item_def in phase_def["items"]:
+            state = states.get(item_def["key"])
+            is_checked = bool(state and state.is_checked)
+            if is_checked:
+                completed += 1
+
+            checked_by_name: Optional[str] = None
+            if state and state.checked_by is not None:
+                checked_by_name = state.checked_by.full_name or state.checked_by.email
+
+            phase_items.append(
+                LaunchReadinessItem(
+                    key=item_def["key"],
+                    title=item_def["title"],
+                    description=item_def.get("description"),
+                    is_checked=is_checked,
+                    checked_by_user_id=state.checked_by_user_id if state else None,
+                    checked_by_user_name=checked_by_name,
+                    checked_at=state.checked_at if state else None,
+                    note=state.note if state else None,
+                )
+            )
+
+        total = len(phase_def["items"])
+        is_complete = completed == total and total > 0
+        if not is_complete and current_phase_number is None:
+            current_phase_number = phase_def["number"]
+
+        phases.append(
+            LaunchReadinessPhase(
+                number=phase_def["number"],
+                slug=phase_def["slug"],
+                title=phase_def["title"],
+                description=phase_def.get("description"),
+                items=phase_items,
+                completed_count=completed,
+                total_count=total,
+                is_complete=is_complete,
+                is_active=False,  # filled in below
+                is_locked=False,  # filled in below
+            )
+        )
+        overall_completed += completed
+
+    # If every phase is complete, there is no "current phase"; keep the
+    # active flag off all phases and signal launch via is_launched.
+    is_launched = current_phase_number is None
+    effective_current = current_phase_number if current_phase_number is not None else (
+        LAUNCH_READINESS_PHASES[-1]["number"] + 1
+    )
+
+    for phase in phases:
+        phase.is_active = phase.number == current_phase_number
+        phase.is_locked = phase.number > effective_current
+
+    return LaunchReadinessState(
+        phases=phases,
+        current_phase_number=effective_current,
+        overall_completed=overall_completed,
+        overall_total=total_item_count(),
+        is_launched=is_launched,
+    )
+
+
+async def _current_phase_number(db: AsyncSession) -> int:
+    """Return the lowest phase number that is not yet 100% complete."""
+    states = await _load_states_by_key(db)
+    for phase_def in LAUNCH_READINESS_PHASES:
+        checked = sum(
+            1
+            for item in phase_def["items"]
+            if item["key"] in states and states[item["key"]].is_checked
+        )
+        if checked < len(phase_def["items"]):
+            return phase_def["number"]
+    return LAUNCH_READINESS_PHASES[-1]["number"] + 1
+
+
+async def _is_phase_complete(db: AsyncSession, phase_number: int) -> bool:
+    """Check whether a given phase is 100% complete."""
+    phase_def = next(
+        (p for p in LAUNCH_READINESS_PHASES if p["number"] == phase_number),
+        None,
+    )
+    if phase_def is None:
+        return False
+    states = await _load_states_by_key(db)
+    for item in phase_def["items"]:
+        row = states.get(item["key"])
+        if row is None or not row.is_checked:
+            return False
+    return True
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+@router.get("", response_model=APIResponse[LaunchReadinessState])
+async def get_launch_readiness(
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return the full Launch Readiness state (phases, items, progress)."""
+    require_superadmin(request)
+    state = await _build_state(db)
+    return APIResponse(success=True, data=state)
+
+
+@router.patch(
+    "/items/{item_key}",
+    response_model=APIResponse[LaunchReadinessState],
+)
+async def toggle_item(
+    item_key: str,
+    payload: LaunchReadinessItemUpdate,
+    request: Request,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Check or uncheck a single item. Enforces that checking only happens in
+    the current phase; unchecking is always allowed.
+    """
+    acting_user_id = require_superadmin(request)
+
+    located = find_item(item_key)
+    if located is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown launch readiness item: {item_key}",
+        )
+    phase_def, _item_def = located
+
+    current_phase = await _current_phase_number(db)
+
+    if payload.checked and phase_def["number"] != current_phase:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Cannot check items in phase {phase_def['number']}: "
+                f"phase {current_phase} must be completed first."
+            ),
+        )
+
+    result = await db.execute(
+        select(LaunchReadinessItemState).where(
+            LaunchReadinessItemState.item_key == item_key
+        )
+    )
+    state_row = result.scalar_one_or_none()
+
+    now = datetime.now(timezone.utc)
+    was_checked = bool(state_row and state_row.is_checked)
+
+    if state_row is None:
+        state_row = LaunchReadinessItemState(
+            phase_number=phase_def["number"],
+            item_key=item_key,
+            is_checked=payload.checked,
+            checked_by_user_id=acting_user_id if payload.checked else None,
+            checked_at=now if payload.checked else None,
+            note=payload.note,
+        )
+        db.add(state_row)
+    else:
+        state_row.is_checked = payload.checked
+        state_row.note = payload.note
+        if payload.checked:
+            state_row.checked_by_user_id = acting_user_id
+            state_row.checked_at = now
+        else:
+            state_row.checked_by_user_id = None
+            state_row.checked_at = None
+
+    # Audit trail. Record the user-driven action; phase-level transitions
+    # are recorded below after we know the post-toggle state.
+    if payload.checked != was_checked:
+        db.add(
+            LaunchReadinessEvent(
+                phase_number=phase_def["number"],
+                item_key=item_key,
+                action="checked" if payload.checked else "unchecked",
+                user_id=acting_user_id,
+                note=payload.note,
+            )
+        )
+
+    await db.flush()
+
+    phase_now_complete = await _is_phase_complete(db, phase_def["number"])
+    if payload.checked and phase_now_complete and not was_checked:
+        db.add(
+            LaunchReadinessEvent(
+                phase_number=phase_def["number"],
+                item_key=None,
+                action="phase_completed",
+                user_id=acting_user_id,
+            )
+        )
+        logger.info(
+            "launch_readiness_phase_completed",
+            phase=phase_def["number"],
+            user_id=acting_user_id,
+        )
+    elif not payload.checked and was_checked:
+        db.add(
+            LaunchReadinessEvent(
+                phase_number=phase_def["number"],
+                item_key=None,
+                action="phase_reopened",
+                user_id=acting_user_id,
+            )
+        )
+        logger.info(
+            "launch_readiness_phase_reopened",
+            phase=phase_def["number"],
+            user_id=acting_user_id,
+            item=item_key,
+        )
+
+    await db.commit()
+
+    state = await _build_state(db)
+    return APIResponse(success=True, data=state)
+
+
+@router.get(
+    "/events",
+    response_model=APIResponse[List[LaunchReadinessEventEntry]],
+)
+async def list_events(
+    request: Request,
+    phase_number: Optional[int] = Query(default=None, ge=1, le=99),
+    limit: int = Query(default=100, ge=1, le=500),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return the audit trail, most recent first."""
+    require_superadmin(request)
+
+    stmt = select(LaunchReadinessEvent).order_by(desc(LaunchReadinessEvent.created_at))
+    if phase_number is not None:
+        stmt = stmt.where(LaunchReadinessEvent.phase_number == phase_number)
+    stmt = stmt.limit(limit)
+
+    result = await db.execute(stmt)
+    rows = result.scalars().all()
+
+    entries: List[LaunchReadinessEventEntry] = []
+    for row in rows:
+        user_name: Optional[str] = None
+        if row.user is not None:
+            user_name = row.user.full_name or row.user.email
+        entries.append(
+            LaunchReadinessEventEntry(
+                id=row.id,
+                phase_number=row.phase_number,
+                item_key=row.item_key,
+                action=row.action,
+                user_id=row.user_id,
+                user_name=user_name,
+                note=row.note,
+                created_at=row.created_at,
+            )
+        )
+
+    return APIResponse(success=True, data=entries)

--- a/backend/app/core/launch_readiness_phases.py
+++ b/backend/app/core/launch_readiness_phases.py
@@ -1,0 +1,285 @@
+# =============================================================================
+# Stratum AI - Launch Readiness Phase Catalog
+# =============================================================================
+"""
+Fixed catalog of go-live phases and their checklist items for the Launch
+Readiness wizard (superadmin-only).
+
+Phases run sequentially: phase N+1 is locked until phase N is 100 percent
+complete. The catalog is static in v1; only per-item state (checked / by
+whom / when) is persisted to the database.
+
+Each item has:
+- key: stable snake_case identifier, unique within its phase
+- title: short label shown in the UI
+- description: longer guidance; optional
+
+Adding or renaming an item is a code change that ships via deploy.
+"""
+
+from typing import List, TypedDict
+
+
+class LaunchReadinessItemDef(TypedDict, total=False):
+    key: str
+    title: str
+    description: str
+
+
+class LaunchReadinessPhaseDef(TypedDict):
+    number: int
+    slug: str
+    title: str
+    description: str
+    items: List[LaunchReadinessItemDef]
+
+
+LAUNCH_READINESS_PHASES: List[LaunchReadinessPhaseDef] = [
+    {
+        "number": 1,
+        "slug": "foundation",
+        "title": "Foundation",
+        "description": "GCP organization, projects, DNS, IAM, VPC, and infrastructure-as-code baseline.",
+        "items": [
+            {"key": "gcp_org_created", "title": "Dedicated GCP Organization created"},
+            {"key": "projects_provisioned", "title": "Prod / staging / shared projects provisioned"},
+            {"key": "domain_registered", "title": "Production domain registered"},
+            {"key": "cloud_dns_zone", "title": "Cloud DNS managed zone configured"},
+            {"key": "org_policies_enabled", "title": "Org policies enabled (uniform bucket access, restrict SA keys, no public IPs)"},
+            {"key": "security_command_center", "title": "Security Command Center enabled (Standard tier)"},
+            {"key": "audit_logs_enabled", "title": "Cloud Audit Logs + VPC Flow Logs enabled"},
+            {"key": "iam_groups_configured", "title": "IAM groups configured via Cloud Identity"},
+            {"key": "workload_identity_federation", "title": "Workload Identity Federation set up for GitHub Actions"},
+            {"key": "service_accounts_created", "title": "Per-workload service accounts created (api, worker, scheduler, migrate)"},
+            {"key": "vpc_created", "title": "VPC with private subnets + Private Google Access"},
+            {"key": "cloud_nat_configured", "title": "Cloud NAT configured for egress"},
+            {"key": "static_ip_reserved", "title": "Static external IP reserved for HTTPS Load Balancer"},
+            {"key": "terraform_repo", "title": "Terraform repository initialised for infra-as-code"},
+        ],
+    },
+    {
+        "number": 2,
+        "slug": "data-layer",
+        "title": "Data Layer",
+        "description": "Cloud SQL for PostgreSQL, Memorystore for Redis, backups, and migrations.",
+        "items": [
+            {"key": "cloud_sql_provisioned", "title": "Cloud SQL PostgreSQL 16 regional (HA) provisioned"},
+            {"key": "cloud_sql_private_ip", "title": "Cloud SQL configured with private IP only"},
+            {"key": "cloud_sql_auth_proxy", "title": "Cloud SQL Auth Proxy configured as workload sidecar"},
+            {"key": "automated_backups", "title": "Automated daily backups, 30-day retention"},
+            {"key": "pitr_enabled", "title": "Point-in-Time Recovery enabled"},
+            {"key": "cross_region_backup", "title": "Cross-region backup copy to DR region"},
+            {"key": "db_flags_tuned", "title": "DB flags tuned (shared_buffers, effective_cache_size, work_mem)"},
+            {"key": "pgbouncer_deployed", "title": "PgBouncer connection pool deployed"},
+            {"key": "memorystore_provisioned", "title": "Memorystore Redis 7 Standard tier (HA) provisioned"},
+            {"key": "redis_tls_auth", "title": "Redis AUTH + in-transit TLS enabled"},
+            {"key": "redis_logical_dbs_verified", "title": "Redis 3-database topology verified (cache / broker / results)"},
+            {"key": "alembic_rehearsal", "title": "`alembic upgrade head` rehearsed against Cloud SQL clone"},
+            {"key": "migration_rollbacks_documented", "title": "Rollback path documented for every risky migration"},
+            {"key": "pg_dump_to_gcs", "title": "Scheduled pg_dump to GCS with lifecycle to Archive class"},
+        ],
+    },
+    {
+        "number": 3,
+        "slug": "container-platform",
+        "title": "Container Platform",
+        "description": "Artifact Registry, GKE Autopilot, Load Balancer, CDN, and Cloud Armor.",
+        "items": [
+            {"key": "artifact_registry_created", "title": "Artifact Registry repository created (multi-region)"},
+            {"key": "image_build_pipeline", "title": "Image build pipeline pushes to Artifact Registry on git SHA"},
+            {"key": "gke_autopilot_cluster", "title": "GKE Autopilot cluster provisioned"},
+            {"key": "private_control_plane", "title": "Private control plane + authorized networks configured"},
+            {"key": "workload_identity_enabled", "title": "Workload Identity enabled on the cluster"},
+            {"key": "binary_authorization", "title": "Binary Authorization requires signed images"},
+            {"key": "manifests_deployed", "title": "Deployment manifests applied (api, worker, scheduler)"},
+            {"key": "hpa_configured", "title": "HorizontalPodAutoscaler on api + worker (custom metrics)"},
+            {"key": "network_policies", "title": "Default-deny NetworkPolicies applied"},
+            {"key": "migrations_as_job", "title": "Alembic migrations run as a Kubernetes Job (not on api startup)"},
+            {"key": "health_probes", "title": "Liveness + readiness probes on `/health`"},
+            {"key": "sql_auth_proxy_sidecar", "title": "Cloud SQL Auth Proxy sidecar on DB-bound pods"},
+            {"key": "frontend_bucket_deployed", "title": "Frontend built + deployed to GCS bucket"},
+            {"key": "https_load_balancer", "title": "HTTPS Load Balancer with URL map (GCS backend + GKE NEG)"},
+            {"key": "managed_ssl_cert", "title": "Google-managed SSL certificate attached"},
+            {"key": "cloud_armor_policy", "title": "Cloud Armor policy applied (rate limit + OWASP rules)"},
+            {"key": "https_redirect_hsts", "title": "HTTP to HTTPS redirect + HSTS preload configured"},
+        ],
+    },
+    {
+        "number": 4,
+        "slug": "secrets-config",
+        "title": "Secrets & Config",
+        "description": "Production secrets generated, stored in Secret Manager, and wired into workloads.",
+        "items": [
+            {"key": "secret_key_generated", "title": "SECRET_KEY generated (32+ chars, random)"},
+            {"key": "jwt_secret_generated", "title": "JWT_SECRET_KEY generated (32+ chars, random)"},
+            {"key": "pii_encryption_key", "title": "PII_ENCRYPTION_KEY generated (Fernet key, base64)"},
+            {"key": "cloud_sql_password", "title": "Cloud SQL password stored in Secret Manager"},
+            {"key": "redis_auth_token", "title": "Redis AUTH token stored in Secret Manager"},
+            {"key": "meta_credentials_stored", "title": "Meta OAuth app credentials + CAPI token stored"},
+            {"key": "google_ads_credentials", "title": "Google Ads developer token + client credentials stored"},
+            {"key": "tiktok_credentials", "title": "TikTok app credentials + CAPI token stored"},
+            {"key": "snapchat_credentials", "title": "Snapchat app credentials + CAPI token stored"},
+            {"key": "whatsapp_credentials", "title": "WhatsApp Business API tokens stored"},
+            {"key": "stripe_live_keys", "title": "Stripe live keys (publishable + secret) stored"},
+            {"key": "stripe_webhook_signing", "title": "Stripe webhook signing secret stored"},
+            {"key": "smtp_credentials", "title": "SMTP / SendGrid credentials stored"},
+            {"key": "sentry_dsn", "title": "Sentry DSN stored"},
+            {"key": "csi_driver_mounted", "title": "Secret Manager CSI driver mounts secrets into pods"},
+            {"key": "cors_origins_set", "title": "CORS_ORIGINS set to exact production frontend URL"},
+            {"key": "mock_ad_data_disabled", "title": "USE_MOCK_AD_DATA set to false"},
+            {"key": "git_history_scanned", "title": "Git history scanned for leaked secrets (gitleaks)"},
+        ],
+    },
+    {
+        "number": 5,
+        "slug": "multi-tenancy",
+        "title": "Multi-Tenancy Hardening",
+        "description": "Tenant isolation verified across every query, every task, every endpoint.",
+        "items": [
+            {"key": "tenant_filter_audit", "title": "Every query audited for tenant_id filter"},
+            {"key": "rls_policies_enabled", "title": "PostgreSQL Row-Level Security policies enabled where defined"},
+            {"key": "cross_tenant_tests", "title": "Integration tests assert 403/404 on cross-tenant access"},
+            {"key": "jwt_tenant_validation", "title": "JWT tenant_id validated on every request"},
+            {"key": "per_tenant_rate_limits", "title": "Rate limits scoped per-tenant, not global"},
+            {"key": "celery_tenant_context", "title": "Celery tasks carry + re-validate tenant context"},
+            {"key": "tenant_audit_log", "title": "Audit log entries scoped per-tenant for autopilot + trust gate"},
+            {"key": "gdpr_erasure_cascade", "title": "GDPR erasure cascade documented + tested"},
+        ],
+    },
+    {
+        "number": 6,
+        "slug": "trust-engine-safety",
+        "title": "Trust Engine / Autopilot Safety",
+        "description": "Guardrails for automation that moves ad spend.",
+        "items": [
+            {"key": "per_tenant_thresholds", "title": "Trust gate thresholds configurable per tenant (never hardcoded)"},
+            {"key": "advisory_default", "title": "New tenants default to Advisory enforcement mode"},
+            {"key": "autopilot_kill_switch", "title": "Global autopilot kill switch feature flag live"},
+            {"key": "circuit_breakers", "title": "Circuit breakers on outbound ad-platform API calls"},
+            {"key": "dry_run_verified", "title": "Dry-run mode verified for every autopilot action type"},
+            {"key": "audit_retention_one_year", "title": "Trust gate + autopilot audit retention set to 1 year minimum"},
+            {"key": "spend_anomaly_alerts", "title": "Spend anomaly alerts configured (N% shift in M minutes)"},
+        ],
+    },
+    {
+        "number": 7,
+        "slug": "observability",
+        "title": "Observability",
+        "description": "Logs, metrics, traces, alerts, and error tracking.",
+        "items": [
+            {"key": "cloud_logging_configured", "title": "Cloud Logging ingesting structured JSON from GKE"},
+            {"key": "log_sinks_long_term", "title": "Log sinks export to GCS for long-term retention"},
+            {"key": "cloud_monitoring_dashboards", "title": "Cloud Monitoring dashboards configured (latency, errors, queue, DB, trust gate)"},
+            {"key": "managed_prometheus", "title": "Managed Service for Prometheus scraping FastAPI instrumentator"},
+            {"key": "managed_grafana", "title": "Managed Grafana configured for dashboards"},
+            {"key": "alerting_integrated", "title": "Alert routing to PagerDuty / Opsgenie / Slack"},
+            {"key": "sentry_configured", "title": "Sentry project configured; source maps uploaded; release tagging"},
+            {"key": "uptime_checks_external", "title": "External synthetic uptime check (not from GCP)"},
+            {"key": "cloud_trace_profiler", "title": "Cloud Trace + Cloud Profiler enabled on api"},
+        ],
+    },
+    {
+        "number": 8,
+        "slug": "security-compliance",
+        "title": "Security & Compliance",
+        "description": "Dependency scanning, pen testing, headers, encryption, legal documents.",
+        "items": [
+            {"key": "dependency_scanning", "title": "CI dependency scanning clears all high / critical"},
+            {"key": "binary_authorization_required", "title": "Binary Authorization attestations required for prod"},
+            {"key": "security_review_completed", "title": "Internal security review of branch completed"},
+            {"key": "third_party_pentest", "title": "Third-party penetration test completed"},
+            {"key": "mfa_required_admins", "title": "MFA required for admin users"},
+            {"key": "csp_headers_verified", "title": "CSP headers verified (Stripe / Meta / GTM allow-lists)"},
+            {"key": "auth_rate_limits", "title": "Rate limits applied to auth endpoints (login, reset, MFA)"},
+            {"key": "pii_fernet_verified", "title": "PII fields verified Fernet-encrypted at rest"},
+            {"key": "gdpr_endpoints_tested", "title": "GDPR export + erasure endpoints tested end-to-end"},
+            {"key": "legal_documents_ready", "title": "ToS, Privacy Policy, DPA templates ready"},
+            {"key": "vpc_service_controls", "title": "VPC Service Controls perimeter around sensitive services"},
+            {"key": "incident_runbook", "title": "Incident response runbook documented"},
+        ],
+    },
+    {
+        "number": 9,
+        "slug": "oauth-compliance",
+        "title": "OAuth & Platform Compliance",
+        "description": "External approvals from ad platforms and payment processors.",
+        "items": [
+            {"key": "meta_app_review_approved", "title": "Meta App Review approved for required scopes"},
+            {"key": "google_ads_token_approved", "title": "Google Ads API production token approved"},
+            {"key": "tiktok_app_approved", "title": "TikTok app approval complete"},
+            {"key": "snapchat_app_approved", "title": "Snapchat app approval complete"},
+            {"key": "stripe_live_mode", "title": "Stripe account activated + live webhook endpoint registered"},
+            {"key": "whatsapp_number_verified", "title": "WhatsApp Business number verified"},
+        ],
+    },
+    {
+        "number": 10,
+        "slug": "deploy-pipeline",
+        "title": "Deploy Pipeline & Rollback",
+        "description": "CI/CD, staging parity, and rollback procedures.",
+        "items": [
+            {"key": "github_actions_wif", "title": "GitHub Actions authenticates via Workload Identity Federation"},
+            {"key": "pipeline_tests_build_push", "title": "Pipeline runs tests, builds, pushes to Artifact Registry"},
+            {"key": "staging_mirrors_prod", "title": "Staging project mirrors prod (smaller sizes)"},
+            {"key": "rolling_deploy_configured", "title": "Rolling deploy configured on GKE Deployments"},
+            {"key": "migration_job_sequencing", "title": "Migration Job runs before api rollout"},
+            {"key": "staging_first_policy", "title": "Staging-first policy enforced for every change"},
+            {"key": "release_notes_automation", "title": "Release notes / change log automation live"},
+        ],
+    },
+    {
+        "number": 11,
+        "slug": "dress-rehearsal",
+        "title": "Pre-Launch Dress Rehearsal",
+        "description": "Load test, failover, restore, secret rotation, DR drills.",
+        "items": [
+            {"key": "load_test_completed", "title": "Load test against staging sustained 30+ minutes"},
+            {"key": "cloud_sql_failover_drill", "title": "Cloud SQL failover drill completed; RTO measured"},
+            {"key": "backup_restore_drill", "title": "PITR restore drill into scratch instance verified"},
+            {"key": "secret_rotation_drill", "title": "Secret rotation drill for JWT_SECRET_KEY completed"},
+            {"key": "dr_drill_completed", "title": "Full DR drill in alternate region completed"},
+            {"key": "security_headers_review", "title": "CORS, CSP, cookie flags reviewed in prod"},
+        ],
+    },
+    {
+        "number": 12,
+        "slug": "launch",
+        "title": "Launch",
+        "description": "Soft launch, monitoring, and progressive enforcement rollout.",
+        "items": [
+            {"key": "pilot_tenants_onboarded", "title": "1 to 3 pilot tenants onboarded"},
+            {"key": "advisory_mode_default", "title": "All tenants start in Advisory enforcement"},
+            {"key": "two_week_monitor_complete", "title": "Two-week monitoring window completed with no P0 / P1"},
+            {"key": "weekly_review_cadence", "title": "Weekly review cadence scheduled (errors, trust gate, autopilot)"},
+            {"key": "enforcement_upgrade_plan", "title": "Per-tenant enforcement upgrade plan documented"},
+            {"key": "postmortem_process", "title": "Post-mortem process documented (48-hour SLA)"},
+        ],
+    },
+]
+
+
+def get_phase_by_number(number: int) -> LaunchReadinessPhaseDef | None:
+    """Return the phase definition for a given phase number, or None."""
+    for phase in LAUNCH_READINESS_PHASES:
+        if phase["number"] == number:
+            return phase
+    return None
+
+
+def find_item(item_key: str) -> tuple[LaunchReadinessPhaseDef, LaunchReadinessItemDef] | None:
+    """Locate the phase and item definition for a given item key."""
+    for phase in LAUNCH_READINESS_PHASES:
+        for item in phase["items"]:
+            if item["key"] == item_key:
+                return phase, item
+    return None
+
+
+def all_item_keys() -> list[tuple[int, str]]:
+    """Return (phase_number, item_key) pairs for every item in the catalog."""
+    return [(phase["number"], item["key"]) for phase in LAUNCH_READINESS_PHASES for item in phase["items"]]
+
+
+def total_item_count() -> int:
+    """Total number of items across all phases."""
+    return sum(len(phase["items"]) for phase in LAUNCH_READINESS_PHASES)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -149,6 +149,12 @@ from app.models.reporting import (
     DeliveryChannelConfig,
 )
 
+# Launch Readiness (Go-Live wizard)
+from app.models.launch_readiness import (
+    LaunchReadinessItemState,
+    LaunchReadinessEvent,
+)
+
 __all__ = [
     "APIKey",
     "AdPlatform",
@@ -209,6 +215,9 @@ __all__ = [
     "FactAttributionVarianceDaily",
     "FactSignalHealthDaily",
     "Forecast",
+    # Launch Readiness (Go-Live wizard)
+    "LaunchReadinessEvent",
+    "LaunchReadinessItemState",
     "MLPrediction",
     "MarginRule",
     # Profit ROAS

--- a/backend/app/models/launch_readiness.py
+++ b/backend/app/models/launch_readiness.py
@@ -1,0 +1,105 @@
+# =============================================================================
+# Stratum AI - Launch Readiness Models
+# =============================================================================
+"""
+Persistence for the Launch Readiness go-live wizard (superadmin-only).
+
+Phase / item metadata lives in ``app.core.launch_readiness_phases`` as a
+static catalog. This module only stores user-driven state:
+
+- ``LaunchReadinessItemState`` — one row per catalog item, tracks whether
+  the item is checked, who checked it, and when.
+- ``LaunchReadinessEvent`` — append-only audit trail of check / uncheck /
+  phase-completed / phase-reopened events.
+
+No tenant_id: this is platform-level, scoped to the Stratum team.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base_class import Base, TimestampMixin
+
+
+class LaunchReadinessItemState(Base, TimestampMixin):
+    """
+    Per-item check state for the Launch Readiness wizard.
+
+    Rows are created lazily on first check. An item with no row is treated
+    as unchecked. The uniqueness constraint guarantees a single row per
+    (phase, item).
+    """
+
+    __tablename__ = "launch_readiness_item_state"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    item_key: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    is_checked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    checked_by_user_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    checked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    checked_by: Mapped[Optional["User"]] = relationship(  # type: ignore[name-defined] # noqa: F821
+        "User", foreign_keys=[checked_by_user_id], lazy="joined"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("phase_number", "item_key", name="uq_launch_readiness_item"),
+        Index("ix_launch_readiness_state_phase", "phase_number"),
+    )
+
+
+class LaunchReadinessEvent(Base):
+    """
+    Append-only audit trail for Launch Readiness actions.
+
+    Action is one of: ``checked``, ``unchecked``, ``phase_completed``,
+    ``phase_reopened``. Phase-level events have a null ``item_key``.
+    """
+
+    __tablename__ = "launch_readiness_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    phase_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    item_key: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    user_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    user: Mapped[Optional["User"]] = relationship(  # type: ignore[name-defined] # noqa: F821
+        "User", foreign_keys=[user_id], lazy="joined"
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_launch_readiness_event_phase_created",
+            "phase_number",
+            "created_at",
+        ),
+        Index("ix_launch_readiness_event_created", "created_at"),
+    )

--- a/backend/app/schemas/launch_readiness.py
+++ b/backend/app/schemas/launch_readiness.py
@@ -1,0 +1,71 @@
+# =============================================================================
+# Stratum AI - Launch Readiness Schemas
+# =============================================================================
+"""
+Pydantic schemas for the Launch Readiness wizard API.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import Field
+
+from app.base_schemas import BaseSchema
+
+
+class LaunchReadinessItem(BaseSchema):
+    """One checklist item inside a phase."""
+
+    key: str
+    title: str
+    description: Optional[str] = None
+    is_checked: bool = False
+    checked_by_user_id: Optional[int] = None
+    checked_by_user_name: Optional[str] = None
+    checked_at: Optional[datetime] = None
+    note: Optional[str] = None
+
+
+class LaunchReadinessPhase(BaseSchema):
+    """A phase containing its items and roll-up state."""
+
+    number: int
+    slug: str
+    title: str
+    description: Optional[str] = None
+    items: List[LaunchReadinessItem]
+    completed_count: int
+    total_count: int
+    is_complete: bool
+    is_active: bool
+    is_locked: bool
+
+
+class LaunchReadinessState(BaseSchema):
+    """Full launch readiness state served to the UI."""
+
+    phases: List[LaunchReadinessPhase]
+    current_phase_number: int
+    overall_completed: int
+    overall_total: int
+    is_launched: bool
+
+
+class LaunchReadinessItemUpdate(BaseSchema):
+    """Payload for toggling an item's checked state."""
+
+    checked: bool
+    note: Optional[str] = Field(default=None, max_length=2000)
+
+
+class LaunchReadinessEventEntry(BaseSchema):
+    """Audit trail entry."""
+
+    id: int
+    phase_number: int
+    item_key: Optional[str] = None
+    action: str
+    user_id: Optional[int] = None
+    user_name: Optional[str] = None
+    note: Optional[str] = None
+    created_at: datetime

--- a/backend/migrations/versions/20260421_000000_046_add_launch_readiness.py
+++ b/backend/migrations/versions/20260421_000000_046_add_launch_readiness.py
@@ -1,0 +1,115 @@
+# =============================================================================
+# Stratum AI - Launch Readiness Tables
+# =============================================================================
+"""Add launch_readiness_item_state + launch_readiness_events tables.
+
+Backs the superadmin-only Launch Readiness wizard (sequential go-live
+phases with append-only audit trail).
+
+Revision ID: 046_add_launch_readiness
+Revises: 25b2d4ee6525
+Create Date: 2026-04-21 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers
+revision = "046_add_launch_readiness"
+down_revision = "25b2d4ee6525"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "launch_readiness_item_state",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column("phase_number", sa.Integer(), nullable=False),
+        sa.Column("item_key", sa.String(length=100), nullable=False),
+        sa.Column("is_checked", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column(
+            "checked_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_unique_constraint(
+        "uq_launch_readiness_item",
+        "launch_readiness_item_state",
+        ["phase_number", "item_key"],
+    )
+    op.create_index(
+        "ix_launch_readiness_state_phase",
+        "launch_readiness_item_state",
+        ["phase_number"],
+    )
+
+    op.create_table(
+        "launch_readiness_events",
+        sa.Column("id", sa.Integer(), autoincrement=True, primary_key=True),
+        sa.Column("phase_number", sa.Integer(), nullable=False),
+        sa.Column("item_key", sa.String(length=100), nullable=True),
+        sa.Column("action", sa.String(length=50), nullable=False),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_launch_readiness_event_phase_created",
+        "launch_readiness_events",
+        ["phase_number", "created_at"],
+    )
+    op.create_index(
+        "ix_launch_readiness_event_created",
+        "launch_readiness_events",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_launch_readiness_event_created",
+        table_name="launch_readiness_events",
+    )
+    op.drop_index(
+        "ix_launch_readiness_event_phase_created",
+        table_name="launch_readiness_events",
+    )
+    op.drop_table("launch_readiness_events")
+
+    op.drop_index(
+        "ix_launch_readiness_state_phase",
+        table_name="launch_readiness_item_state",
+    )
+    op.drop_constraint(
+        "uq_launch_readiness_item",
+        "launch_readiness_item_state",
+        type_="unique",
+    )
+    op.drop_table("launch_readiness_item_state")

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -448,6 +448,7 @@ def setup_test_database(sync_engine):
     import app.models.profit  # noqa: F401
     import app.models.reporting  # noqa: F401
     import app.models.settings  # noqa: F401
+    import app.models.launch_readiness  # noqa: F401
 
     # Drop and recreate all tables for a clean state
     Base.metadata.drop_all(bind=sync_engine)

--- a/backend/tests/integration/test_launch_readiness_api.py
+++ b/backend/tests/integration/test_launch_readiness_api.py
@@ -1,0 +1,342 @@
+# =============================================================================
+# Stratum AI - Launch Readiness API Integration Tests
+# =============================================================================
+"""
+Integration tests for the Launch Readiness go-live wizard.
+
+Covers:
+- Auth: superadmin-only access (401 without auth, 403 for non-superadmin)
+- Initial state: 12 phases, phase 1 active, phases 2-12 locked
+- Phase-gate enforcement: checking outside the current phase returns 409
+- Sequential unlock: completing phase N exposes phase N+1
+- Re-open: unchecking a completed item relocks downstream phases
+- Audit trail: events appended for check/uncheck and phase transitions
+- Error paths: 404 for unknown item_key
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.launch_readiness_phases import LAUNCH_READINESS_PHASES
+
+
+pytestmark = pytest.mark.integration
+
+BASE = "/api/v1/superadmin/launch-readiness"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+def _phase_items(phase_number: int):
+    """Return the list of item keys for a given phase number."""
+    phase = next(p for p in LAUNCH_READINESS_PHASES if p["number"] == phase_number)
+    return [i["key"] for i in phase["items"]]
+
+
+async def _complete_phase(
+    client: AsyncClient, headers: dict, phase_number: int
+) -> None:
+    """Check every item in a phase. Caller must ensure phase is currently active."""
+    for key in _phase_items(phase_number):
+        response = await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": True},
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"failed to check {key} in phase {phase_number}: "
+            f"{response.status_code} {response.text}"
+        )
+
+
+# =============================================================================
+# Auth
+# =============================================================================
+class TestLaunchReadinessAuth:
+    @pytest.mark.asyncio
+    async def test_unauthenticated_request_is_rejected(self, client: AsyncClient):
+        response = await client.get(BASE)
+        # TenantMiddleware rejects before reaching the endpoint
+        assert response.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_non_superadmin_cannot_access(
+        self, authenticated_client: AsyncClient
+    ):
+        # authenticated_client uses the test_user fixture (role=admin)
+        response = await authenticated_client.get(BASE)
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_superadmin_can_access(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        response = await client.get(BASE, headers=superadmin_headers)
+        assert response.status_code == 200
+
+
+# =============================================================================
+# Initial state
+# =============================================================================
+class TestInitialState:
+    @pytest.mark.asyncio
+    async def test_returns_twelve_phases(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        response = await client.get(BASE, headers=superadmin_headers)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+
+        state = body["data"]
+        assert len(state["phases"]) == 12
+        assert state["current_phase_number"] == 1
+        assert state["overall_completed"] == 0
+        assert state["is_launched"] is False
+
+    @pytest.mark.asyncio
+    async def test_phase_one_is_active_and_others_locked(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        response = await client.get(BASE, headers=superadmin_headers)
+        state = response.json()["data"]
+
+        for phase in state["phases"]:
+            if phase["number"] == 1:
+                assert phase["is_active"] is True
+                assert phase["is_locked"] is False
+                assert phase["is_complete"] is False
+            else:
+                assert phase["is_active"] is False
+                assert phase["is_locked"] is True
+
+    @pytest.mark.asyncio
+    async def test_all_items_start_unchecked(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        response = await client.get(BASE, headers=superadmin_headers)
+        state = response.json()["data"]
+
+        for phase in state["phases"]:
+            for item in phase["items"]:
+                assert item["is_checked"] is False
+                assert item["checked_by_user_id"] is None
+                assert item["checked_at"] is None
+
+
+# =============================================================================
+# Phase-gate enforcement
+# =============================================================================
+class TestPhaseGating:
+    @pytest.mark.asyncio
+    async def test_check_item_in_current_phase_succeeds(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        key = _phase_items(1)[0]
+        response = await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": True},
+            headers=superadmin_headers,
+        )
+
+        assert response.status_code == 200
+        state = response.json()["data"]
+        toggled = next(i for i in state["phases"][0]["items"] if i["key"] == key)
+        assert toggled["is_checked"] is True
+        assert toggled["checked_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_check_item_outside_current_phase_returns_409(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        # Phase 2 items are locked until phase 1 is complete
+        key = _phase_items(2)[0]
+        response = await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": True},
+            headers=superadmin_headers,
+        )
+
+        assert response.status_code == 409
+        body = response.json()
+        assert "phase" in body["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unknown_item_key_returns_404(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        response = await client.patch(
+            f"{BASE}/items/totally_not_a_real_key",
+            json={"checked": True},
+            headers=superadmin_headers,
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_completing_phase_one_unlocks_phase_two(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        await _complete_phase(client, superadmin_headers, 1)
+
+        response = await client.get(BASE, headers=superadmin_headers)
+        state = response.json()["data"]
+
+        phase_one = state["phases"][0]
+        phase_two = state["phases"][1]
+
+        assert phase_one["is_complete"] is True
+        assert phase_one["is_active"] is False
+        assert phase_two["is_active"] is True
+        assert phase_two["is_locked"] is False
+        assert state["current_phase_number"] == 2
+
+    @pytest.mark.asyncio
+    async def test_cannot_skip_to_phase_three_without_phase_two(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        await _complete_phase(client, superadmin_headers, 1)
+
+        key = _phase_items(3)[0]
+        response = await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": True},
+            headers=superadmin_headers,
+        )
+        assert response.status_code == 409
+
+
+# =============================================================================
+# Uncheck / re-open
+# =============================================================================
+class TestReopen:
+    @pytest.mark.asyncio
+    async def test_uncheck_in_active_phase_is_allowed(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        key = _phase_items(1)[0]
+        await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": True},
+            headers=superadmin_headers,
+        )
+
+        response = await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": False},
+            headers=superadmin_headers,
+        )
+
+        assert response.status_code == 200
+        state = response.json()["data"]
+        toggled = next(i for i in state["phases"][0]["items"] if i["key"] == key)
+        assert toggled["is_checked"] is False
+
+    @pytest.mark.asyncio
+    async def test_uncheck_in_completed_phase_relocks_downstream(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        # Complete phase 1, then uncheck one of its items.
+        await _complete_phase(client, superadmin_headers, 1)
+
+        response = await client.get(BASE, headers=superadmin_headers)
+        assert response.json()["data"]["current_phase_number"] == 2
+
+        key = _phase_items(1)[0]
+        await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": False},
+            headers=superadmin_headers,
+        )
+
+        response = await client.get(BASE, headers=superadmin_headers)
+        state = response.json()["data"]
+        assert state["current_phase_number"] == 1
+        assert state["phases"][0]["is_active"] is True
+        assert state["phases"][1]["is_locked"] is True
+
+
+# =============================================================================
+# Audit trail
+# =============================================================================
+class TestAuditTrail:
+    @pytest.mark.asyncio
+    async def test_check_appends_event(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        key = _phase_items(1)[0]
+        await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": True, "note": "first check"},
+            headers=superadmin_headers,
+        )
+
+        response = await client.get(
+            f"{BASE}/events", headers=superadmin_headers
+        )
+        assert response.status_code == 200
+
+        events = response.json()["data"]
+        # Most-recent first. Top event should be the 'checked' action.
+        assert len(events) >= 1
+        top = events[0]
+        assert top["action"] == "checked"
+        assert top["item_key"] == key
+        assert top["note"] == "first check"
+
+    @pytest.mark.asyncio
+    async def test_phase_completion_emits_phase_completed_event(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        await _complete_phase(client, superadmin_headers, 1)
+
+        response = await client.get(
+            f"{BASE}/events",
+            headers=superadmin_headers,
+            params={"phase_number": 1},
+        )
+        events = response.json()["data"]
+
+        actions = [e["action"] for e in events]
+        assert "phase_completed" in actions
+
+    @pytest.mark.asyncio
+    async def test_uncheck_after_completion_emits_phase_reopened(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        await _complete_phase(client, superadmin_headers, 1)
+
+        key = _phase_items(1)[0]
+        await client.patch(
+            f"{BASE}/items/{key}",
+            json={"checked": False},
+            headers=superadmin_headers,
+        )
+
+        response = await client.get(
+            f"{BASE}/events",
+            headers=superadmin_headers,
+            params={"phase_number": 1},
+        )
+        events = response.json()["data"]
+        actions = [e["action"] for e in events]
+        assert "phase_reopened" in actions
+
+    @pytest.mark.asyncio
+    async def test_events_ordered_newest_first(
+        self, client: AsyncClient, superadmin_headers: dict
+    ):
+        items = _phase_items(1)[:3]
+        for key in items:
+            await client.patch(
+                f"{BASE}/items/{key}",
+                json={"checked": True},
+                headers=superadmin_headers,
+            )
+
+        response = await client.get(
+            f"{BASE}/events", headers=superadmin_headers, params={"limit": 50}
+        )
+        events = response.json()["data"]
+        timestamps = [e["created_at"] for e in events]
+        assert timestamps == sorted(timestamps, reverse=True)

--- a/backend/tests/unit/test_launch_readiness_phases.py
+++ b/backend/tests/unit/test_launch_readiness_phases.py
@@ -1,0 +1,117 @@
+# =============================================================================
+# Stratum AI - Launch Readiness Phase Catalog (Unit Tests)
+# =============================================================================
+"""
+Invariants for the static Launch Readiness phase catalog. These run without
+a database or any framework imports.
+"""
+
+import pytest
+
+from app.core.launch_readiness_phases import (
+    LAUNCH_READINESS_PHASES,
+    all_item_keys,
+    find_item,
+    get_phase_by_number,
+    total_item_count,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_catalog_has_exactly_twelve_phases():
+    assert len(LAUNCH_READINESS_PHASES) == 12
+
+
+def test_phase_numbers_are_contiguous_from_one():
+    numbers = [p["number"] for p in LAUNCH_READINESS_PHASES]
+    assert numbers == list(range(1, 13))
+
+
+def test_phase_slugs_are_unique():
+    slugs = [p["slug"] for p in LAUNCH_READINESS_PHASES]
+    assert len(set(slugs)) == len(slugs)
+
+
+def test_phase_slugs_are_kebab_case():
+    import re
+
+    pattern = re.compile(r"^[a-z][a-z0-9-]*$")
+    for phase in LAUNCH_READINESS_PHASES:
+        assert pattern.match(phase["slug"]), f"bad slug: {phase['slug']}"
+
+
+def test_every_phase_has_a_title_and_description():
+    for phase in LAUNCH_READINESS_PHASES:
+        assert phase["title"], f"phase {phase['number']} missing title"
+        assert phase["description"], f"phase {phase['number']} missing description"
+
+
+def test_every_phase_has_at_least_one_item():
+    for phase in LAUNCH_READINESS_PHASES:
+        assert len(phase["items"]) >= 1, f"phase {phase['number']} has no items"
+
+
+def test_item_keys_are_globally_unique():
+    keys = [item["key"] for phase in LAUNCH_READINESS_PHASES for item in phase["items"]]
+    assert len(set(keys)) == len(keys)
+
+
+def test_item_keys_are_snake_case():
+    import re
+
+    pattern = re.compile(r"^[a-z][a-z0-9_]*$")
+    for phase in LAUNCH_READINESS_PHASES:
+        for item in phase["items"]:
+            assert pattern.match(item["key"]), f"bad item key: {item['key']}"
+
+
+def test_item_key_length_fits_column():
+    # item_key column is String(100); keep a safety margin.
+    for phase in LAUNCH_READINESS_PHASES:
+        for item in phase["items"]:
+            assert len(item["key"]) <= 100
+
+
+def test_every_item_has_a_title():
+    for phase in LAUNCH_READINESS_PHASES:
+        for item in phase["items"]:
+            assert item["title"].strip(), f"empty title for {item['key']}"
+
+
+def test_total_item_count_matches_sum_of_phases():
+    manual = sum(len(p["items"]) for p in LAUNCH_READINESS_PHASES)
+    assert total_item_count() == manual
+
+
+def test_all_item_keys_returns_every_key_with_phase_number():
+    pairs = all_item_keys()
+    assert len(pairs) == total_item_count()
+    for phase_number, key in pairs:
+        phase = get_phase_by_number(phase_number)
+        assert phase is not None
+        assert any(i["key"] == key for i in phase["items"])
+
+
+def test_find_item_returns_phase_and_item_for_known_key():
+    located = find_item("gcp_org_created")
+    assert located is not None
+    phase, item = located
+    assert phase["number"] == 1
+    assert item["key"] == "gcp_org_created"
+
+
+def test_find_item_returns_none_for_unknown_key():
+    assert find_item("totally_made_up_key_xyz") is None
+
+
+def test_get_phase_by_number_returns_matching_phase():
+    phase = get_phase_by_number(3)
+    assert phase is not None
+    assert phase["title"] == "Container Platform"
+
+
+def test_get_phase_by_number_returns_none_for_out_of_range():
+    assert get_phase_by_number(0) is None
+    assert get_phase_by_number(99) is None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -110,6 +110,7 @@ const SuperAdminBilling = lazyWithRetry(() => import('./views/superadmin/Billing
 const SuperAdminSystem = lazyWithRetry(() => import('./views/superadmin/System'));
 // SuperAdminCMS removed — CMS is now a separate portal at /cms
 const SuperAdminUsers = lazyWithRetry(() => import('./views/superadmin/Users'));
+const SuperAdminLaunchReadiness = lazyWithRetry(() => import('./views/superadmin/LaunchReadiness'));
 
 // CMS (Content Management System) - Separate Portal
 const CMSLogin = lazyWithRetry(() => import('./views/CMSLogin'));
@@ -1253,6 +1254,16 @@ function App() {
                           <ProtectedRoute requiredRole="superadmin">
                             <Suspense fallback={<LoadingSpinner />}>
                               <SuperAdminUsers />
+                            </Suspense>
+                          </ProtectedRoute>
+                        }
+                      />
+                      <Route
+                        path="superadmin/launch-readiness"
+                        element={
+                          <ProtectedRoute requiredRole="superadmin">
+                            <Suspense fallback={<LoadingSpinner />}>
+                              <SuperAdminLaunchReadiness />
                             </Suspense>
                           </ProtectedRoute>
                         }

--- a/frontend/src/api/launchReadiness.ts
+++ b/frontend/src/api/launchReadiness.ts
@@ -1,0 +1,143 @@
+/**
+ * Stratum AI - Launch Readiness API
+ *
+ * Superadmin-only. Drives the sequential go-live wizard: phase N+1 is
+ * locked until phase N is 100% complete. Each check/uncheck appends to
+ * an immutable audit trail.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient, ApiResponse } from './client'
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+export interface LaunchReadinessItem {
+  key: string
+  title: string
+  description?: string | null
+  is_checked: boolean
+  checked_by_user_id?: number | null
+  checked_by_user_name?: string | null
+  checked_at?: string | null
+  note?: string | null
+}
+
+export interface LaunchReadinessPhase {
+  number: number
+  slug: string
+  title: string
+  description?: string | null
+  items: LaunchReadinessItem[]
+  completed_count: number
+  total_count: number
+  is_complete: boolean
+  is_active: boolean
+  is_locked: boolean
+}
+
+export interface LaunchReadinessState {
+  phases: LaunchReadinessPhase[]
+  current_phase_number: number
+  overall_completed: number
+  overall_total: number
+  is_launched: boolean
+}
+
+export type LaunchReadinessEventAction =
+  | 'checked'
+  | 'unchecked'
+  | 'phase_completed'
+  | 'phase_reopened'
+
+export interface LaunchReadinessEvent {
+  id: number
+  phase_number: number
+  item_key?: string | null
+  action: LaunchReadinessEventAction | string
+  user_id?: number | null
+  user_name?: string | null
+  note?: string | null
+  created_at: string
+}
+
+export interface ToggleItemRequest {
+  itemKey: string
+  checked: boolean
+  note?: string
+}
+
+// -----------------------------------------------------------------------------
+// API functions
+// -----------------------------------------------------------------------------
+export const launchReadinessApi = {
+  getState: async (): Promise<LaunchReadinessState> => {
+    const response = await apiClient.get<ApiResponse<LaunchReadinessState>>(
+      '/superadmin/launch-readiness'
+    )
+    return response.data.data
+  },
+
+  toggleItem: async ({
+    itemKey,
+    checked,
+    note,
+  }: ToggleItemRequest): Promise<LaunchReadinessState> => {
+    const response = await apiClient.patch<ApiResponse<LaunchReadinessState>>(
+      `/superadmin/launch-readiness/items/${encodeURIComponent(itemKey)}`,
+      { checked, note: note ?? null }
+    )
+    return response.data.data
+  },
+
+  getEvents: async (params: { phaseNumber?: number; limit?: number } = {}): Promise<
+    LaunchReadinessEvent[]
+  > => {
+    const response = await apiClient.get<ApiResponse<LaunchReadinessEvent[]>>(
+      '/superadmin/launch-readiness/events',
+      {
+        params: {
+          phase_number: params.phaseNumber,
+          limit: params.limit ?? 100,
+        },
+      }
+    )
+    return response.data.data
+  },
+}
+
+// -----------------------------------------------------------------------------
+// React Query hooks
+// -----------------------------------------------------------------------------
+const stateKey = ['launch-readiness', 'state'] as const
+const eventsKey = (phaseNumber?: number) =>
+  ['launch-readiness', 'events', phaseNumber ?? 'all'] as const
+
+export function useLaunchReadinessState() {
+  return useQuery({
+    queryKey: stateKey,
+    queryFn: launchReadinessApi.getState,
+    staleTime: 10 * 1000,
+  })
+}
+
+export function useToggleLaunchReadinessItem() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: launchReadinessApi.toggleItem,
+    onSuccess: (state) => {
+      // Server already returned the fresh state; seed the cache
+      // then invalidate the events log.
+      queryClient.setQueryData(stateKey, state)
+      queryClient.invalidateQueries({ queryKey: ['launch-readiness', 'events'] })
+    },
+  })
+}
+
+export function useLaunchReadinessEvents(phaseNumber?: number, limit = 100) {
+  return useQuery({
+    queryKey: eventsKey(phaseNumber),
+    queryFn: () => launchReadinessApi.getEvents({ phaseNumber, limit }),
+    staleTime: 30 * 1000,
+  })
+}

--- a/frontend/src/views/DashboardLayout.tsx
+++ b/frontend/src/views/DashboardLayout.tsx
@@ -40,6 +40,7 @@ import {
   HomeIcon,
   PhotoIcon,
   PresentationChartBarIcon,
+  RocketLaunchIcon,
   ShareIcon,
   ShieldCheckIcon,
   ShieldExclamationIcon,
@@ -628,6 +629,7 @@ export default function DashboardLayout() {
                           end: true,
                         },
                         { href: '/dashboard/superadmin/users', icon: UserGroupIcon, name: 'Users' },
+                        { href: '/dashboard/superadmin/launch-readiness', icon: RocketLaunchIcon, name: 'Launch Readiness' },
                       ].map((item) => {
                         const isActive = location.pathname === item.href;
                         return (

--- a/frontend/src/views/superadmin/LaunchReadiness.test.tsx
+++ b/frontend/src/views/superadmin/LaunchReadiness.test.tsx
@@ -1,0 +1,390 @@
+/**
+ * Launch Readiness view tests
+ *
+ * Covers:
+ * - Header and overall progress rendering
+ * - All 12 phases render
+ * - The active phase is auto-expanded; locked phases show a lock badge
+ * - Locked phase items cannot be toggled (checkbox disabled)
+ * - Toggling an item in the active phase fires the mutation
+ * - Unchecking an item in a completed phase triggers a confirm prompt
+ *   and is cancelled if the user declines
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+import LaunchReadiness from './LaunchReadiness'
+import type {
+  LaunchReadinessState,
+  LaunchReadinessPhase,
+} from '@/api/launchReadiness'
+
+// -----------------------------------------------------------------------------
+// Mocks
+// Factories for vi.mock are hoisted to the top of the file, so they can
+// only reference symbols that are available at module-load time. Use
+// createElement (not JSX) and vi.hoisted() for shared fn state.
+// -----------------------------------------------------------------------------
+const { mockUseState, mockUseEvents, mockToggleMutate } = vi.hoisted(() => ({
+  mockUseState: vi.fn(),
+  mockUseEvents: vi.fn(),
+  mockToggleMutate: vi.fn(),
+}))
+
+vi.mock('@/api/launchReadiness', () => ({
+  useLaunchReadinessState: () => mockUseState(),
+  useLaunchReadinessEvents: () => mockUseEvents(),
+  useToggleLaunchReadinessItem: () => ({
+    mutate: mockToggleMutate,
+    isPending: false,
+  }),
+}))
+
+// Explicit icon exports — avoid Proxy-based factories because vitest's
+// module namespace resolution treats those as broken modules.
+vi.mock('@heroicons/react/24/outline', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react')
+  const Icon = (props: Record<string, unknown>) =>
+    React.createElement('svg', props)
+  return {
+    CheckCircleIcon: Icon,
+    LockClosedIcon: Icon,
+    ChevronDownIcon: Icon,
+    ChevronRightIcon: Icon,
+    ClockIcon: Icon,
+    RocketLaunchIcon: Icon,
+    ExclamationTriangleIcon: Icon,
+    BoltIcon: Icon,
+  }
+})
+
+vi.mock('@heroicons/react/24/solid', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require('react')
+  const Icon = (props: Record<string, unknown>) =>
+    React.createElement('svg', props)
+  return {
+    CheckCircleIcon: Icon,
+  }
+})
+
+// -----------------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------------
+function makePhase(
+  number: number,
+  overrides: Partial<LaunchReadinessPhase> = {}
+): LaunchReadinessPhase {
+  const base: LaunchReadinessPhase = {
+    number,
+    slug: `phase-${number}`,
+    title: `Phase ${number}`,
+    description: `Description for phase ${number}`,
+    items: [
+      {
+        key: `p${number}_item_a`,
+        title: `Phase ${number} item A`,
+        description: null,
+        is_checked: false,
+      },
+      {
+        key: `p${number}_item_b`,
+        title: `Phase ${number} item B`,
+        description: null,
+        is_checked: false,
+      },
+    ],
+    completed_count: 0,
+    total_count: 2,
+    is_complete: false,
+    is_active: false,
+    is_locked: true,
+  }
+  return { ...base, ...overrides }
+}
+
+function makeState(currentPhase: number): LaunchReadinessState {
+  const phases: LaunchReadinessPhase[] = Array.from({ length: 12 }, (_, i) => {
+    const n = i + 1
+    if (n < currentPhase) {
+      return makePhase(n, {
+        items: [
+          {
+            key: `p${n}_item_a`,
+            title: `Phase ${n} item A`,
+            description: null,
+            is_checked: true,
+            checked_by_user_name: 'Test Admin',
+            checked_at: '2026-04-20T10:00:00Z',
+          },
+          {
+            key: `p${n}_item_b`,
+            title: `Phase ${n} item B`,
+            description: null,
+            is_checked: true,
+            checked_by_user_name: 'Test Admin',
+            checked_at: '2026-04-20T10:05:00Z',
+          },
+        ],
+        completed_count: 2,
+        is_complete: true,
+        is_active: false,
+        is_locked: false,
+      })
+    }
+    if (n === currentPhase) {
+      return makePhase(n, { is_active: true, is_locked: false })
+    }
+    return makePhase(n, { is_locked: true })
+  })
+
+  const overallCompleted = phases.reduce((s, p) => s + p.completed_count, 0)
+  const overallTotal = phases.reduce((s, p) => s + p.total_count, 0)
+
+  return {
+    phases,
+    current_phase_number: currentPhase,
+    overall_completed: overallCompleted,
+    overall_total: overallTotal,
+    is_launched: false,
+  }
+}
+
+function renderView() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children)
+  return render(createElement(LaunchReadiness), { wrapper: Wrapper })
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+describe('LaunchReadiness', () => {
+  beforeEach(() => {
+    mockUseState.mockReset()
+    mockUseEvents.mockReset()
+    mockToggleMutate.mockReset()
+    // Default: events empty
+    mockUseEvents.mockReturnValue({ data: [], isLoading: false })
+  })
+
+  it('shows a loading skeleton while state is loading', () => {
+    mockUseState.mockReturnValue({ data: undefined, isLoading: true, error: null })
+    const { container } = renderView()
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+  })
+
+  it('renders the header and overall progress', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(3),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+    expect(screen.getByText('Launch Readiness')).toBeInTheDocument()
+    // Phase 1 and 2 complete = 4 of 24 total items checked → 17%
+    expect(screen.getByText(/17%/)).toBeInTheDocument()
+    expect(screen.getByText('/ 24')).toBeInTheDocument()
+    expect(screen.getByText(/Phase 3 of 12/)).toBeInTheDocument()
+  })
+
+  it('renders all twelve phase cards', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(1),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+    for (let n = 1; n <= 12; n++) {
+      expect(screen.getByText(`Phase ${n} — Phase ${n}`)).toBeInTheDocument()
+    }
+  })
+
+  it('auto-expands the active phase and shows In progress badge', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(2),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+    // Active phase shows its items inline. Completed phases are
+    // collapsed by default (only active auto-expands).
+    expect(screen.getByText('Phase 2 item A')).toBeInTheDocument()
+    expect(screen.getByText('Phase 2 item B')).toBeInTheDocument()
+    expect(screen.getAllByText('In progress').length).toBeGreaterThan(0)
+  })
+
+  it('shows Locked pills on phases beyond the current one', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(1),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+    // Phases 2–12 are locked.
+    expect(screen.getAllByText('Locked').length).toBe(11)
+  })
+
+  it('shows Complete pills on phases before the current one', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(4),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+    expect(screen.getAllByText('Complete').length).toBe(3)
+  })
+
+  it('fires the toggle mutation when clicking an unchecked item in the active phase', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(2),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+
+    // Active phase (2) is auto-expanded and has 2 items.
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes.length).toBeGreaterThanOrEqual(2)
+
+    fireEvent.click(checkboxes[0])
+
+    expect(mockToggleMutate).toHaveBeenCalledTimes(1)
+    const call = mockToggleMutate.mock.calls[0][0]
+    expect(call.itemKey).toMatch(/^p2_item_/)
+    expect(call.checked).toBe(true)
+  })
+
+  it('does not fire the mutation when a locked-phase item is clicked', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(1),
+      isLoading: false,
+      error: null,
+    })
+    const { container } = renderView()
+
+    // Find a locked phase card and expand it manually.
+    const phase4Header = screen.getByText('Phase 4 — Phase 4').closest('button')!
+    fireEvent.click(phase4Header)
+
+    // Click should be a no-op because the checkbox is disabled.
+    const allCheckboxes = container.querySelectorAll('[role="checkbox"]')
+    const lockedBox = Array.from(allCheckboxes).find(
+      (el) => (el as HTMLButtonElement).disabled
+    )
+    expect(lockedBox).toBeDefined()
+    fireEvent.click(lockedBox!)
+    expect(mockToggleMutate).not.toHaveBeenCalled()
+  })
+
+  it('prompts for confirmation when unchecking a completed-phase item, and respects cancel', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(3),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+
+    // Expand a completed phase (phase 1).
+    const phase1Header = screen.getByText('Phase 1 — Phase 1').closest('button')!
+    fireEvent.click(phase1Header)
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    // Find the first checkbox inside the phase 1 region (both items checked).
+    const allCheckboxes = screen.getAllByRole('checkbox') as HTMLButtonElement[]
+    const checkedBoxes = allCheckboxes.filter(
+      (b) => b.getAttribute('aria-checked') === 'true'
+    )
+    expect(checkedBoxes.length).toBeGreaterThan(0)
+    fireEvent.click(checkedBoxes[0])
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockToggleMutate).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('proceeds with the mutation when the user confirms the reopen prompt', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(3),
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+
+    const phase1Header = screen.getByText('Phase 1 — Phase 1').closest('button')!
+    fireEvent.click(phase1Header)
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const checkedBoxes = (
+      screen.getAllByRole('checkbox') as HTMLButtonElement[]
+    ).filter((b) => b.getAttribute('aria-checked') === 'true')
+    fireEvent.click(checkedBoxes[0])
+
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(mockToggleMutate).toHaveBeenCalledTimes(1)
+    const call = mockToggleMutate.mock.calls[0][0]
+    expect(call.checked).toBe(false)
+    confirmSpy.mockRestore()
+  })
+
+  it('shows a cleared-to-launch message when every phase is complete', () => {
+    const state = makeState(13) // currentPhase beyond last phase = all done
+    state.is_launched = true
+    // makeState(13) marks every phase as "before current" → all complete
+    mockUseState.mockReturnValue({
+      data: state,
+      isLoading: false,
+      error: null,
+    })
+    renderView()
+    expect(screen.getByText(/cleared to launch/i)).toBeInTheDocument()
+  })
+
+  it('renders an error message when the state query fails', () => {
+    mockUseState.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    })
+    renderView()
+    expect(
+      screen.getByText(/Failed to load Launch Readiness state/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders the audit trail with events', () => {
+    mockUseState.mockReturnValue({
+      data: makeState(2),
+      isLoading: false,
+      error: null,
+    })
+    mockUseEvents.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          phase_number: 1,
+          item_key: 'p1_item_a',
+          action: 'checked',
+          user_id: 1,
+          user_name: 'Alice',
+          note: null,
+          created_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      isLoading: false,
+    })
+    renderView()
+
+    const activity = screen.getByText('Activity').parentElement!.parentElement!
+    expect(within(activity).getByText('checked')).toBeInTheDocument()
+    expect(within(activity).getByText(/p1_item_a/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/views/superadmin/LaunchReadiness.tsx
+++ b/frontend/src/views/superadmin/LaunchReadiness.tsx
@@ -1,0 +1,520 @@
+/**
+ * Launch Readiness (Super Admin Go-Live Wizard)
+ *
+ * Sequential 12-phase launch gate for multi-tenant production. Phase N+1
+ * stays locked until phase N is 100% complete. Every check and uncheck
+ * appends to an audit trail. No skip.
+ */
+
+import { useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+import {
+  CheckCircleIcon,
+  LockClosedIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ClockIcon,
+  RocketLaunchIcon,
+  ExclamationTriangleIcon,
+  BoltIcon,
+} from '@heroicons/react/24/outline'
+import { CheckCircleIcon as CheckCircleSolid } from '@heroicons/react/24/solid'
+import {
+  useLaunchReadinessState,
+  useToggleLaunchReadinessItem,
+  useLaunchReadinessEvents,
+  type LaunchReadinessItem,
+  type LaunchReadinessPhase,
+} from '@/api/launchReadiness'
+
+type PhaseStatus = 'complete' | 'active' | 'locked'
+
+function phaseStatus(phase: LaunchReadinessPhase): PhaseStatus {
+  if (phase.is_complete) return 'complete'
+  if (phase.is_active) return 'active'
+  return 'locked'
+}
+
+function formatRelative(isoDate: string | null | undefined): string {
+  if (!isoDate) return ''
+  const then = new Date(isoDate).getTime()
+  const now = Date.now()
+  const diff = Math.max(0, now - then)
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(isoDate).toLocaleDateString()
+}
+
+export default function LaunchReadiness() {
+  const { data: state, isLoading, error } = useLaunchReadinessState()
+  const [expandedPhases, setExpandedPhases] = useState<Set<number>>(new Set())
+
+  // Once the state is known, auto-expand the active phase on first render.
+  const activePhaseNumber = state?.phases.find((p) => p.is_active)?.number
+  const effectiveExpanded = useMemo(() => {
+    if (expandedPhases.size > 0) return expandedPhases
+    if (activePhaseNumber) return new Set([activePhaseNumber])
+    return new Set<number>()
+  }, [expandedPhases, activePhaseNumber])
+
+  const togglePhase = (n: number) => {
+    setExpandedPhases((prev) => {
+      const next = new Set(prev.size === 0 && activePhaseNumber ? [activePhaseNumber] : prev)
+      if (next.has(n)) next.delete(n)
+      else next.add(n)
+      return next
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="h-24 rounded-2xl bg-surface-secondary border border-white/10 animate-pulse" />
+        <div className="space-y-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-20 rounded-2xl bg-surface-secondary border border-white/10 animate-pulse"
+            />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !state) {
+    return (
+      <div className="rounded-2xl bg-danger/10 border border-danger/20 p-6">
+        <div className="flex items-center gap-3 text-danger">
+          <ExclamationTriangleIcon className="w-5 h-5" />
+          <span className="font-medium">Failed to load Launch Readiness state.</span>
+        </div>
+      </div>
+    )
+  }
+
+  const overallPct =
+    state.overall_total === 0
+      ? 0
+      : Math.round((state.overall_completed / state.overall_total) * 100)
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <header className="space-y-2">
+        <div className="flex items-center gap-3">
+          <RocketLaunchIcon className="w-6 h-6 text-stratum-400" />
+          <h1 className="text-2xl font-bold text-white tracking-tight">Launch Readiness</h1>
+        </div>
+        <p className="text-text-muted max-w-2xl">
+          Sequential go-live gate. Each phase must be 100% complete before the next
+          unlocks. No skipping. Every check is recorded in the audit trail.
+        </p>
+      </header>
+
+      {/* Overall progress card */}
+      <section className="rounded-2xl bg-surface-secondary border border-white/10 p-6">
+        <div className="flex items-start justify-between gap-6 flex-wrap">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-widest text-text-muted">
+              Overall progress
+            </p>
+            <p className="text-3xl font-bold text-white">
+              {state.overall_completed}
+              <span className="text-text-muted font-normal text-xl">
+                {' / '}
+                {state.overall_total}
+              </span>
+              <span className="ml-3 text-base text-text-muted font-normal">
+                ({overallPct}%)
+              </span>
+            </p>
+            <p className="text-sm text-text-muted">
+              {state.is_launched ? (
+                <span className="inline-flex items-center gap-2 text-success font-medium">
+                  <CheckCircleSolid className="w-4 h-4" />
+                  All phases complete — cleared to launch.
+                </span>
+              ) : (
+                <>
+                  Currently in{' '}
+                  <span className="text-white font-medium">
+                    Phase {state.current_phase_number} of {state.phases.length}
+                  </span>
+                </>
+              )}
+            </p>
+          </div>
+          <div className="flex-1 min-w-[240px] max-w-xl">
+            <div className="h-2 rounded-full bg-white/5 overflow-hidden">
+              <div
+                className={cn(
+                  'h-full rounded-full transition-all duration-500',
+                  state.is_launched
+                    ? 'bg-gradient-to-r from-success to-success/70'
+                    : 'bg-gradient-to-r from-stratum-500 to-stratum-400'
+                )}
+                style={{ width: `${overallPct}%` }}
+              />
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {state.phases.map((phase) => {
+                const st = phaseStatus(phase)
+                return (
+                  <button
+                    key={phase.number}
+                    onClick={() => togglePhase(phase.number)}
+                    className={cn(
+                      'w-8 h-8 rounded-lg text-xs font-semibold flex items-center justify-center transition-colors',
+                      st === 'complete' &&
+                        'bg-success/20 text-success border border-success/30',
+                      st === 'active' &&
+                        'bg-stratum-500/20 text-stratum-300 border border-stratum-400/40 ring-2 ring-stratum-400/30',
+                      st === 'locked' &&
+                        'bg-white/5 text-text-muted border border-white/10'
+                    )}
+                    title={`Phase ${phase.number} — ${phase.title} (${st})`}
+                  >
+                    {phase.number}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Phase list */}
+      <section className="space-y-4">
+        {state.phases.map((phase) => (
+          <PhaseCard
+            key={phase.number}
+            phase={phase}
+            expanded={effectiveExpanded.has(phase.number)}
+            onToggleExpand={() => togglePhase(phase.number)}
+          />
+        ))}
+      </section>
+
+      {/* Audit trail */}
+      <AuditTrail />
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Phase card
+// -----------------------------------------------------------------------------
+interface PhaseCardProps {
+  phase: LaunchReadinessPhase
+  expanded: boolean
+  onToggleExpand: () => void
+}
+
+function PhaseCard({ phase, expanded, onToggleExpand }: PhaseCardProps) {
+  const status = phaseStatus(phase)
+  const pct =
+    phase.total_count === 0
+      ? 0
+      : Math.round((phase.completed_count / phase.total_count) * 100)
+
+  return (
+    <article
+      className={cn(
+        'rounded-2xl border transition-colors overflow-hidden',
+        status === 'complete' && 'bg-surface-secondary border-success/20',
+        status === 'active' &&
+          'bg-surface-secondary border-stratum-400/40 shadow-[0_0_0_1px_rgba(168,85,247,0.15)]',
+        status === 'locked' && 'bg-surface-secondary/60 border-white/5'
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        className="w-full p-5 flex items-center gap-4 text-left"
+        aria-expanded={expanded}
+      >
+        {/* Status badge */}
+        <div
+          className={cn(
+            'w-12 h-12 rounded-xl flex items-center justify-center font-bold text-lg shrink-0',
+            status === 'complete' && 'bg-success/15 text-success border border-success/30',
+            status === 'active' && 'bg-stratum-500/20 text-stratum-300 border border-stratum-400/40',
+            status === 'locked' && 'bg-white/5 text-text-muted border border-white/10'
+          )}
+        >
+          {status === 'complete' ? (
+            <CheckCircleSolid className="w-6 h-6" />
+          ) : status === 'locked' ? (
+            <LockClosedIcon className="w-5 h-5" />
+          ) : (
+            phase.number
+          )}
+        </div>
+
+        {/* Title + description */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h2
+              className={cn(
+                'text-lg font-semibold tracking-tight',
+                status === 'locked' ? 'text-text-muted' : 'text-white'
+              )}
+            >
+              Phase {phase.number} — {phase.title}
+            </h2>
+            <StatusPill status={status} />
+          </div>
+          {phase.description && (
+            <p className="text-sm text-text-muted mt-1 line-clamp-1">
+              {phase.description}
+            </p>
+          )}
+        </div>
+
+        {/* Progress */}
+        <div className="hidden md:flex flex-col items-end gap-2 min-w-[160px]">
+          <div className="text-sm font-medium">
+            <span className={status === 'locked' ? 'text-text-muted' : 'text-white'}>
+              {phase.completed_count}
+            </span>
+            <span className="text-text-muted">{' / '}{phase.total_count}</span>
+          </div>
+          <div className="w-40 h-1.5 rounded-full bg-white/5 overflow-hidden">
+            <div
+              className={cn(
+                'h-full rounded-full transition-all duration-500',
+                status === 'complete' && 'bg-success',
+                status === 'active' && 'bg-stratum-400',
+                status === 'locked' && 'bg-white/20'
+              )}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Chevron */}
+        <div className="shrink-0 text-text-muted">
+          {expanded ? (
+            <ChevronDownIcon className="w-5 h-5" />
+          ) : (
+            <ChevronRightIcon className="w-5 h-5" />
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-white/5 bg-surface-primary/30 px-5 py-4 space-y-2">
+          {status === 'locked' && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-white/5 border border-white/10 mb-2">
+              <LockClosedIcon className="w-4 h-4 text-text-muted mt-0.5 shrink-0" />
+              <p className="text-sm text-text-muted">
+                This phase is locked. Complete the preceding phase first — no skipping.
+              </p>
+            </div>
+          )}
+          {phase.items.map((item) => (
+            <ItemRow
+              key={item.key}
+              item={item}
+              disabled={status === 'locked'}
+              phaseIsComplete={status === 'complete'}
+            />
+          ))}
+        </div>
+      )}
+    </article>
+  )
+}
+
+function StatusPill({ status }: { status: PhaseStatus }) {
+  if (status === 'complete') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium bg-success/15 text-success border border-success/30">
+        <CheckCircleIcon className="w-3 h-3" />
+        Complete
+      </span>
+    )
+  }
+  if (status === 'active') {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium bg-stratum-500/20 text-stratum-300 border border-stratum-400/40">
+        <BoltIcon className="w-3 h-3" />
+        In progress
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium bg-white/5 text-text-muted border border-white/10">
+      <LockClosedIcon className="w-3 h-3" />
+      Locked
+    </span>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Item row
+// -----------------------------------------------------------------------------
+interface ItemRowProps {
+  item: LaunchReadinessItem
+  disabled: boolean
+  phaseIsComplete: boolean
+}
+
+function ItemRow({ item, disabled, phaseIsComplete }: ItemRowProps) {
+  const toggle = useToggleLaunchReadinessItem()
+
+  const handleClick = () => {
+    if (disabled) return
+    // If the phase is complete and the user is unchecking, warn first —
+    // the backend will reopen the phase and relock all downstream phases.
+    if (phaseIsComplete && item.is_checked) {
+      const ok = window.confirm(
+        'Unchecking this item will reopen this phase and relock every phase after it. Continue?'
+      )
+      if (!ok) return
+    }
+    toggle.mutate({ itemKey: item.key, checked: !item.is_checked })
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 p-3 rounded-lg border',
+        item.is_checked
+          ? 'bg-success/5 border-success/15'
+          : 'bg-white/[0.02] border-white/5',
+        disabled && 'opacity-60'
+      )}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || toggle.isPending}
+        aria-checked={item.is_checked}
+        role="checkbox"
+        className={cn(
+          'mt-0.5 w-5 h-5 rounded-md flex items-center justify-center shrink-0 transition-all',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-stratum-400',
+          item.is_checked
+            ? 'bg-success border border-success text-white'
+            : 'bg-transparent border border-white/20 hover:border-white/40',
+          (disabled || toggle.isPending) && 'cursor-not-allowed'
+        )}
+      >
+        {item.is_checked && (
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        )}
+      </button>
+
+      <div className="flex-1 min-w-0">
+        <p
+          className={cn(
+            'text-sm',
+            item.is_checked ? 'text-white' : 'text-white/90',
+            disabled && 'text-text-muted'
+          )}
+        >
+          {item.title}
+        </p>
+        {item.description && (
+          <p className="text-xs text-text-muted mt-0.5">{item.description}</p>
+        )}
+        {item.is_checked && (item.checked_by_user_name || item.checked_at) && (
+          <p className="text-xs text-text-muted mt-1.5 flex items-center gap-1.5">
+            <CheckCircleIcon className="w-3 h-3 text-success" />
+            {item.checked_by_user_name && <span>{item.checked_by_user_name}</span>}
+            {item.checked_by_user_name && item.checked_at && <span>·</span>}
+            {item.checked_at && <span>{formatRelative(item.checked_at)}</span>}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// -----------------------------------------------------------------------------
+// Audit trail
+// -----------------------------------------------------------------------------
+function AuditTrail() {
+  const { data: events, isLoading } = useLaunchReadinessEvents(undefined, 50)
+
+  return (
+    <section className="rounded-2xl bg-surface-secondary border border-white/10 p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <ClockIcon className="w-5 h-5 text-text-muted" />
+        <h2 className="text-lg font-semibold text-white">Activity</h2>
+      </div>
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-8 rounded bg-white/5 animate-pulse" />
+          ))}
+        </div>
+      ) : !events || events.length === 0 ? (
+        <p className="text-sm text-text-muted">No activity yet.</p>
+      ) : (
+        <ol className="space-y-2">
+          {events.map((event) => (
+            <li
+              key={event.id}
+              className="flex items-start gap-3 text-sm border-l-2 border-white/10 pl-3 py-1"
+            >
+              <ActionBadge action={event.action} />
+              <div className="flex-1 min-w-0">
+                <p className="text-white/90">
+                  <span className="text-text-muted">Phase {event.phase_number}</span>
+                  {event.item_key && (
+                    <>
+                      <span className="text-text-muted">{' · '}</span>
+                      <span className="font-mono text-xs">{event.item_key}</span>
+                    </>
+                  )}
+                </p>
+                <p className="text-xs text-text-muted">
+                  {event.user_name ?? 'system'} · {formatRelative(event.created_at)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}
+
+function ActionBadge({ action }: { action: string }) {
+  const label = action.replace(/_/g, ' ')
+  const styles =
+    action === 'checked'
+      ? 'bg-success/15 text-success border-success/30'
+      : action === 'unchecked'
+        ? 'bg-warning/15 text-warning border-warning/30'
+        : action === 'phase_completed'
+          ? 'bg-stratum-500/20 text-stratum-300 border-stratum-400/40'
+          : action === 'phase_reopened'
+            ? 'bg-danger/15 text-danger border-danger/30'
+            : 'bg-white/5 text-text-muted border-white/10'
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border shrink-0',
+        styles
+      )}
+    >
+      {label}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

A superadmin-only Launch Readiness wizard that enforces the 12-phase multi-tenant go-live as a sequential gate. Phase N+1 is locked until phase N is 100% complete. Every check / uncheck appends to an immutable audit trail. No skipping.

The 12 phases and 124 checklist items are the GCP multi-tenant production punch list produced in the chat that preceded this branch (Foundation → Data Layer → Container Platform → Secrets → Multi-Tenancy Hardening → Trust Engine Safety → Observability → Security & Compliance → OAuth Compliance → Deploy Pipeline → Dress Rehearsal → Launch).

## Changes

### Backend (`/api/v1/superadmin/launch-readiness`, superadmin-only)
- `GET /` — full state (phases, items, rollups, current-phase pointer, `is_launched`)
- `PATCH /items/{key}` — toggle a single item. **409** if the item is outside the current phase; unchecking is always allowed and naturally reopens the phase.
- `GET /events` — audit trail, newest first
- Models: `LaunchReadinessItemState` (unique on `phase_number + item_key`) and `LaunchReadinessEvent` (append-only)
- Alembic migration `046_add_launch_readiness` from the current merge head `25b2d4ee6525`
- Static phase catalog in `app/core/launch_readiness_phases.py`

### Frontend (`/dashboard/superadmin/launch-readiness`)
- `api/launchReadiness.ts` — React Query hooks
- `views/superadmin/LaunchReadiness.tsx` — 12 phase cards (complete / active / locked), overall progress rail, audit trail timeline
- Sidebar entry under the Superadmin section (RocketLaunch icon)
- Confirm prompt on uncheck-of-completed-item (reopens phase and relocks downstream)

### Tests
- `tests/unit/test_launch_readiness_phases.py` — **16 catalog invariants**
- `tests/integration/test_launch_readiness_api.py` — **17 integration tests** (auth, phase gating, sequential unlock, reopen, audit trail, 404)
- `views/superadmin/LaunchReadiness.test.tsx` — **13 Vitest cases** (loading, rendering, locked/active/complete states, toggle mutation, confirm-on-reopen, cleared-to-launch, error, audit rendering)
- `tests/integration/conftest.py` — registers the new model so `Base.metadata.create_all` builds the tables for integration runs

## Local run

```
backend:   pytest tests/unit/test_launch_readiness_phases.py       →  16/16 pass (0.23s)
backend:   pytest tests/integration/test_launch_readiness_api.py   →  collects clean (live DB required to execute; CI runs them)
frontend:  vitest run src/views/superadmin/LaunchReadiness.test.tsx → 13/13 pass (1.62s)
frontend:  tsc --noEmit -p tsconfig.build.json                     →  clean
```

## Test plan

- [ ] `make migrate` applies `046_add_launch_readiness` cleanly
- [ ] Log in as superadmin; `/dashboard/superadmin/launch-readiness` renders with phase 1 active and phases 2–12 locked
- [ ] Check an item in phase 1; progress bar advances
- [ ] Try to check a phase 2 item via a crafted PATCH → returns 409
- [ ] Complete phase 1 → phase 2 becomes active
- [ ] Uncheck a phase 1 item via the UI → confirm prompt appears; confirming relocks phase 2
- [ ] `/superadmin/launch-readiness/events` returns the ordered audit trail
- [ ] Non-superadmin hitting any of these endpoints gets 403

## Notes

- No tenant scoping — this is a platform-level launch gate for the Stratum team, not a per-tenant onboarding flow.
- v2 would move the phase catalog into the DB for admin-editable phases and add per-item assignment / due dates.

https://claude.ai/code/session_01NbXJQFwq3sFPWGdChRDCiu