### PR TITLE
fix(frontend): allow api.stratumai.app in CSP connect-src

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -41,7 +41,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.up.railway.app https://app.stratumai.app https://api.stripe.com https://*.sentry.io wss: ws:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.up.railway.app https://app.stratumai.app https://api.stratumai.app https://api.stripe.com https://*.sentry.io wss: ws:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     }
 
@@ -54,7 +54,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.up.railway.app https://app.stratumai.app https://api.stripe.com https://*.sentry.io wss: ws:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.googletagmanager.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.up.railway.app https://app.stratumai.app https://api.stratumai.app https://api.stripe.com https://*.sentry.io wss: ws:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Why

Browser console on `https://stratumai.app` was blocking every API call to `https://api.stratumai.app/api/v1/...` with:

```
Connecting to 'https://api.stratumai.app/api/v1/auth/login' violates the following
Content Security Policy directive: "connect-src 'self' https://*.up.railway.app
https://app.stratumai.app https://api.stripe.com https://*.sentry.io wss: ws:".
The action has been blocked.
```

Login is impossible — every fetch throws `TypeError: Failed to fetch`, which `AuthContext.tsx` surfaces as "Cannot reach server".

## Root cause

The nginx CSP allow-list included `https://app.stratumai.app` (a placeholder subdomain that was never attached) but not `https://api.stratumai.app` (the backend's actual custom domain).

`frontend/nginx.conf` has three CSP headers — one per location block:

| Line | Block | Had `api.stratumai.app`? |
|---|---|---|
| 32 | `/landing.html` | ✅ yes |
| 44 | `location ~* \.html$` | ❌ missing |
| 57 | `location /` (SPA fallback — the one that serves `index.html` for React routes) | ❌ missing |

The SPA fallback is what the browser receives on every dashboard route, so its CSP is what was actually blocking the app.

## Change

Added `https://api.stratumai.app` to `connect-src` in the two missing blocks. The `/landing.html` block and `nginx.railway.conf` (unused today, but kept in sync) already had it — no change needed there.

## Out of scope (for future cleanup)

- `https://app.stratumai.app` is still listed in all three CSP blocks but isn't attached to any Railway service. Harmless to keep — leaving it avoids breaking anything that might still reference it — but could be cleaned up later.
- Moving the CSP string to a named include file to avoid this triple-maintenance pattern.

## Test plan

- [ ] CI passes
- [ ] Railway rebuilds frontend
- [ ] After deploy: `curl -sI https://stratumai.app/ | grep -i content-security-policy` shows `api.stratumai.app` in `connect-src`
- [ ] Login via `https://stratumai.app/` in an incognito window succeeds; no "Refused to connect" error in browser console

https://claude.ai/code/session_01NbXJQFwq3sFPWGdChRDCiu