### PR TITLE
feat(scripts): read superadmin seed values from env vars

### DIFF
--- a/backend/scripts/seed_superadmin.py
+++ b/backend/scripts/seed_superadmin.py
@@ -31,11 +31,23 @@ from app.core.security import encrypt_pii, get_password_hash, hash_pii_for_looku
 # Super Admin Configuration (read from env vars with fallbacks for dev only)
 # =============================================================================
 
-SUPERADMIN_EMAIL = "ibrahim@new-aeon.com"
-SUPERADMIN_PASSWORD = "Newaeon@2026"
-SUPERADMIN_NAME = "Ibrahim (Super Admin)"
-SUPERADMIN_TENANT_NAME = "Stratum Platform"
-SUPERADMIN_TENANT_SLUG = "stratum-platform"
+# =============================================================================
+# Super Admin Configuration
+# Reads from env vars with safe fallbacks. Set these in your Railway
+# Backend service Variables (or .env) to override the defaults.
+#
+#   SUPERADMIN_EMAIL          e.g. admin@yourcompany.com
+#   SUPERADMIN_PASSWORD       strong password, 12+ chars
+#   SUPERADMIN_NAME           display name
+#   SUPERADMIN_TENANT_NAME    top-level platform tenant name
+#   SUPERADMIN_TENANT_SLUG    url-safe slug for the tenant
+# =============================================================================
+
+SUPERADMIN_EMAIL = os.getenv("SUPERADMIN_EMAIL", "ibrahim@new-aeon.com")
+SUPERADMIN_PASSWORD = os.getenv("SUPERADMIN_PASSWORD", "Newaeon@2026")
+SUPERADMIN_NAME = os.getenv("SUPERADMIN_NAME", "Ibrahim (Super Admin)")
+SUPERADMIN_TENANT_NAME = os.getenv("SUPERADMIN_TENANT_NAME", "Stratum Platform")
+SUPERADMIN_TENANT_SLUG = os.getenv("SUPERADMIN_TENANT_SLUG", "stratum-platform")
 
 
 async def create_superadmin():


### PR DESCRIPTION
## Why

The superadmin seed script hardcodes credentials, making it impossible to customize them without editing the repo:

```python
SUPERADMIN_EMAIL = "ibrahim@new-aeon.com"
SUPERADMIN_PASSWORD = "Newaeon@2026"
```

`backend/start.sh` already tries to pass `SUPERADMIN_PASSWORD` into the script's env, but the script ignores it because the module-level constant shadows any env lookup.

## What

Switch all five fields to `os.getenv(..., <current default>)`. Same defaults as before — no behavior change when env vars aren't set.

After this merges, in Railway Backend service → Variables you can set:

```
SUPERADMIN_EMAIL=you@yourcompany.com
SUPERADMIN_PASSWORD=<strong-password-12+-chars>
SUPERADMIN_NAME=Your Name
SUPERADMIN_TENANT_NAME=Your Company
SUPERADMIN_TENANT_SLUG=your-company
SEED_SUPERADMIN=true
```

Then restart the backend. The seed script will pick up the new values and create (or find existing) superadmin with those credentials.

## Out of scope

- Forcing env vars to be set (no required=True) — keeping backward compatibility with existing deploys.
- Migration path to rotate the hardcoded password on existing DBs — the script is idempotent; it checks for an existing user first and skips creation. Password rotation still needs to be done via UI or a separate migration.

https://claude.ai/code/session_01NbXJQFwq3sFPWGdChRDCiu