### PR TITLE
fix(migrations): merge alembic heads 046_add_launch_readiness and 046…

### DIFF
--- a/backend/migrations/versions/20260426_133718_e21f74be91a2_merge_launch_readiness_and_drop_.py
+++ b/backend/migrations/versions/20260426_133718_e21f74be91a2_merge_launch_readiness_and_drop_.py
@@ -1,0 +1,26 @@
+"""Merge launch_readiness and drop_orphaned_autopilot heads
+
+Revision ID: e21f74be91a2
+Revises: 046_add_launch_readiness, 046_drop_orphaned_autopilot_020_tables
+Create Date: 2026-04-26 13:37:18.893056+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e21f74be91a2'
+down_revision: Union[str, None] = ('046_add_launch_readiness', '046_drop_orphaned_autopilot_020_tables')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
…_drop_orphaned_autopilot_020_tables

Railway deployment failed with:
'Multiple head revisions are present for given argument head'

Created merge migration e21f74be91a2 to unify the two divergent migration branches so alembic upgrade head can run cleanly.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
