### PR TITLE
fix(nginx): strip host/port from redirects so /landing.html stays on …

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Railway terminates TLS on 443 and forwards to nginx on $PORT (e.g. 8080).
+    # Without these, nginx builds redirect URLs like https://host:8080/... which
+    # the browser can't reach. Relative redirects let the browser resolve
+    # against the original URL → stays on the public scheme + port.
+    absolute_redirect off;
+    port_in_redirect off;
+
     # Gzip compression
     gzip on;
     gzip_vary on;


### PR DESCRIPTION
…public 443

Railway forwards TLS-terminated requests to the container on  (8080), so nginx's default absolute redirect builds Location: https://host:8080/... which the browser can't reach. absolute_redirect off + port_in_redirect off make nginx send relative Location headers — the browser resolves them against the original URL and stays on https://stratumai.app.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
