### PR TITLE
fix(theme): figma-themed loader for auth Suspense + ink pre-paint

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Stratum AI — Your AI Partner for Unstoppable Ad Growth. Enterprise-grade intelligence, automation, and optimization across every ad platform." />
-    <meta name="theme-color" content="#050B18" />
+    <meta name="theme-color" content="#0B0B0B" />
+    <style>html, body { background-color: #0B0B0B; margin: 0; }</style>
     <title>Stratum AI — Your AI Partner for Ad Growth</title>
     <!-- Fonts: Geist (auth/marketing surfaces), Clash Display + Satoshi (dashboard), Cairo (Arabic) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
 import { DemoProvider } from './contexts/DemoContext';
 import LoadingSpinner from './components/common/LoadingSpinner';
+import AuthLoader from './components/auth/AuthLoader';
 import ProtectedRoute from './components/auth/ProtectedRoute';
 import CMSProtectedRoute from './components/auth/CMSProtectedRoute';
 import OnboardingGuard from './components/auth/OnboardingGuard';
@@ -90,15 +91,23 @@ const CDPPredictiveChurn = lazyWithRetry(() => import('./views/cdp/CDPPredictive
 // Newsletter / Email Campaigns views
 const NewsletterDashboard = lazyWithRetry(() => import('./views/newsletter/NewsletterDashboard'));
 const NewsletterCampaigns = lazyWithRetry(() => import('./views/newsletter/NewsletterCampaigns'));
-const NewsletterCampaignEditor = lazyWithRetry(() => import('./views/newsletter/NewsletterCampaignEditor'));
+const NewsletterCampaignEditor = lazyWithRetry(
+  () => import('./views/newsletter/NewsletterCampaignEditor')
+);
 const NewsletterTemplates = lazyWithRetry(() => import('./views/newsletter/NewsletterTemplates'));
-const NewsletterSubscribers = lazyWithRetry(() => import('./views/newsletter/NewsletterSubscribers'));
+const NewsletterSubscribers = lazyWithRetry(
+  () => import('./views/newsletter/NewsletterSubscribers')
+);
 const NewsletterAnalytics = lazyWithRetry(() => import('./views/newsletter/NewsletterAnalytics'));
 
 // Knowledge Graph views
 const KnowledgeGraphInsights = lazyWithRetry(() => import('./views/KnowledgeGraphInsights'));
-const KGProblemDetection = lazyWithRetry(() => import('./views/knowledge-graph/KGProblemDetection'));
-const KGRevenueAttribution = lazyWithRetry(() => import('./views/knowledge-graph/KGRevenueAttribution'));
+const KGProblemDetection = lazyWithRetry(
+  () => import('./views/knowledge-graph/KGProblemDetection')
+);
+const KGRevenueAttribution = lazyWithRetry(
+  () => import('./views/knowledge-graph/KGRevenueAttribution')
+);
 
 // Super Admin views
 const ControlTower = lazyWithRetry(() => import('./views/superadmin/ControlTower'));
@@ -191,7 +200,9 @@ const ApiDocsPage = lazyWithRetry(() => import('./views/pages/ApiDocs'));
 // Public pages (Solutions)
 const CDPSolutionPage = lazyWithRetry(() => import('./views/pages/solutions/CDP'));
 const AudienceSyncPage = lazyWithRetry(() => import('./views/pages/solutions/AudienceSync'));
-const PredictionsSolutionPage = lazyWithRetry(() => import('./views/pages/solutions/PredictionsSolution'));
+const PredictionsSolutionPage = lazyWithRetry(
+  () => import('./views/pages/solutions/PredictionsSolution')
+);
 const TrustEnginePage = lazyWithRetry(() => import('./views/pages/solutions/TrustEngine'));
 
 // Public pages (Company)
@@ -224,7 +235,9 @@ const CheckoutSuccess = lazyWithRetry(() => import('./views/checkout/CheckoutSuc
 const CheckoutCancel = lazyWithRetry(() => import('./views/checkout/CheckoutCancel'));
 
 // Announcement pages
-const AudienceSyncLaunch = lazyWithRetry(() => import('./views/pages/announcements/AudienceSyncLaunch'));
+const AudienceSyncLaunch = lazyWithRetry(
+  () => import('./views/pages/announcements/AudienceSyncLaunch')
+);
 
 // Gap implementation views
 const AIInsights = lazyWithRetry(() => import('./views/AIInsights'));
@@ -278,7 +291,7 @@ function App() {
                       path="/login"
                       element={
                         <ErrorBoundary message="Failed to load the login page">
-                          <Suspense fallback={<LoadingSpinner />}>
+                          <Suspense fallback={<AuthLoader />}>
                             <Login />
                           </Suspense>
                         </ErrorBoundary>
@@ -288,7 +301,7 @@ function App() {
                       path="/signup"
                       element={
                         <ErrorBoundary message="Failed to load the signup page">
-                          <Suspense fallback={<LoadingSpinner />}>
+                          <Suspense fallback={<AuthLoader />}>
                             <Signup />
                           </Suspense>
                         </ErrorBoundary>
@@ -298,7 +311,7 @@ function App() {
                       path="/forgot-password"
                       element={
                         <ErrorBoundary message="Failed to load the page">
-                          <Suspense fallback={<LoadingSpinner />}>
+                          <Suspense fallback={<AuthLoader />}>
                             <ForgotPassword />
                           </Suspense>
                         </ErrorBoundary>
@@ -308,7 +321,7 @@ function App() {
                       path="/reset-password"
                       element={
                         <ErrorBoundary message="Failed to load the page">
-                          <Suspense fallback={<LoadingSpinner />}>
+                          <Suspense fallback={<AuthLoader />}>
                             <ResetPassword />
                           </Suspense>
                         </ErrorBoundary>
@@ -318,7 +331,7 @@ function App() {
                       path="/verify-email"
                       element={
                         <ErrorBoundary message="Failed to load the page">
-                          <Suspense fallback={<LoadingSpinner />}>
+                          <Suspense fallback={<AuthLoader />}>
                             <VerifyEmail />
                           </Suspense>
                         </ErrorBoundary>
@@ -469,7 +482,13 @@ function App() {
                       <Route
                         path="users"
                         element={
-                          <Suspense fallback={<div className="flex items-center justify-center min-h-screen"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyan-400" /></div>}>
+                          <Suspense
+                            fallback={
+                              <div className="flex items-center justify-center min-h-screen">
+                                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyan-400" />
+                              </div>
+                            }
+                          >
                             <CMSUsers />
                           </Suspense>
                         }

--- a/frontend/src/components/auth/AuthLoader.tsx
+++ b/frontend/src/components/auth/AuthLoader.tsx
@@ -1,0 +1,36 @@
+/**
+ * AuthLoader — figma-themed full-screen Suspense fallback for auth routes.
+ * Used while /login, /signup, /forgot-password, /verify-email chunks load.
+ * Keeps the ink/ember theme cohesive with the landing → form transition.
+ */
+
+export default function AuthLoader() {
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center bg-[#0B0B0B] text-white"
+      style={{ fontFamily: 'Geist, system-ui, sans-serif' }}
+    >
+      <div
+        className="absolute inset-x-0 top-0 h-72 pointer-events-none"
+        style={{
+          background:
+            'radial-gradient(60% 60% at 50% 0%, rgba(255,90,31,0.16) 0%, rgba(255,90,31,0.04) 40%, transparent 70%)',
+        }}
+        aria-hidden="true"
+      />
+      <div className="flex flex-col items-center gap-4 relative z-10">
+        <div
+          className="w-10 h-10 rounded-full border-2 border-[#1F1F1F] border-t-[#FF5A1F] animate-spin"
+          role="status"
+          aria-label="Loading"
+        />
+        <span
+          className="text-[11px] uppercase tracking-[0.12em] text-[#6B6B6B]"
+          style={{ fontFamily: 'Geist Mono, monospace' }}
+        >
+          Loading
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- AuthLoader: ink-bg, ember-ring spinner, Geist mono "Loading" label. Replaces the cyber-pink LoadingSpinner on /login, /signup, /forgot-password, /reset-password, /verify-email Suspense fallbacks so the figma → form transition stays cohesive.
- index.html: body bg #0B0B0B inline + theme-color #0B0B0B so the pre-React paint matches the landing instead of flashing white / midnight blue. Tailwind's body bg-background still applies once CSS loads (dashboard interior unchanged).

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
