### PR TITLE
fix(auth): back-to-site uses full page load to figma landing

### DIFF
--- a/frontend/src/components/auth/AuthLeftPanel.test.tsx
+++ b/frontend/src/components/auth/AuthLeftPanel.test.tsx
@@ -29,11 +29,13 @@ describe('AuthLeftPanel', () => {
     expect(container.firstChild).toBeInTheDocument();
   });
 
-  it('renders the stratum.ai wordmark linking home', () => {
+  it('renders the stratum.ai wordmark linking to the figma landing', () => {
     render(<AuthLeftPanel />);
     const wordmark = screen.getAllByText('stratum.ai')[0];
     expect(wordmark).toBeInTheDocument();
-    expect(wordmark.closest('a')).toHaveAttribute('href', '/');
+    // Plain <a> (not React Router Link) so the browser does a full page
+    // load and lands on the figma marketing page, not the SPA route.
+    expect(wordmark.closest('a')).toHaveAttribute('href', '/landing.html');
   });
 
   it('renders the testimonial', () => {

--- a/frontend/src/components/auth/AuthLeftPanel.tsx
+++ b/frontend/src/components/auth/AuthLeftPanel.tsx
@@ -3,7 +3,6 @@
  * Stratum figma theme — ink surface, ember accent, Geist typography
  */
 
-import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 
 interface AuthLeftPanelProps {
@@ -30,17 +29,17 @@ export default function AuthLeftPanel({ className }: AuthLeftPanelProps) {
         aria-hidden="true"
       />
 
-      {/* Top: logo + back-home */}
+      {/* Top: logo + back-home (plain <a> for full page load → figma landing) */}
       <div className="relative z-10 flex items-center justify-between">
-        <Link to="/" className="flex items-center gap-2" aria-label="Stratum AI home">
+        <a href="/landing.html" className="flex items-center gap-2" aria-label="Stratum AI home">
           <span className="text-[19px] font-medium tracking-tight text-white">stratum.ai</span>
-        </Link>
-        <Link
-          to="/"
+        </a>
+        <a
+          href="/landing.html"
           className="text-[12px] text-[#9A9A9A] hover:text-white transition-colors flex items-center gap-1"
         >
           ← Back to site
-        </Link>
+        </a>
       </div>
 
       {/* Center: testimonial */}

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -132,9 +132,9 @@ export default function Login() {
 
           {/* Mobile wordmark */}
           <div className="lg:hidden mb-8 self-start">
-            <Link to="/" className="text-[18px] font-medium tracking-tight text-white">
+            <a href="/landing.html" className="text-[18px] font-medium tracking-tight text-white">
               stratum.ai
-            </Link>
+            </a>
           </div>
 
           <div className="w-full max-w-[420px] relative z-10">

--- a/frontend/src/views/Signup.tsx
+++ b/frontend/src/views/Signup.tsx
@@ -606,9 +606,9 @@ export default function Signup() {
 
           {/* Mobile wordmark */}
           <div className="lg:hidden mb-8 self-start">
-            <Link to="/" className="text-[18px] font-medium tracking-tight text-white">
+            <a href="/landing.html" className="text-[18px] font-medium tracking-tight text-white">
               stratum.ai
-            </Link>
+            </a>
           </div>
 
           <div className="w-full max-w-[440px] relative z-10">


### PR DESCRIPTION
React Router's <Link to="/"> navigates client-side via pushState, so the nginx redirect (/ → /landing.html) is bypassed and the SPA's in-app Landing route renders instead — which is the OLD theme.

Switched the wordmark + back-to-site links in AuthLeftPanel, Login.tsx, and Signup.tsx from <Link to="/"> to plain <a href="/landing.html"> so the browser does a full page load and lands on the figma marketing page. Test assertion updated.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
