### PR TITLE
fix(nginx): widen landing-page CSP to all /landing-*.html variants

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,15 +28,18 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
     }
 
-    # Landing page - needs Tailwind CDN + inline scripts (separate CSP)
-    location = /landing.html {
+    # Landing pages - need Tailwind CDN + inline scripts (separate CSP).
+    # Matches /landing.html and any /landing-<variant>.html (e.g. landing-bombon.html).
+    # Regex location runs after exact `=` matches but before the generic `~* \.html$` block,
+    # so this wins over the strict default CSP for landing variants.
+    location ~ ^/landing(-[a-z0-9]+)?\.html$ {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.up.railway.app https://app.stratumai.app https://api.stratumai.app https://api.stripe.com https://*.sentry.io wss: ws:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net https://www.googletagmanager.com https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.up.railway.app https://app.stratumai.app https://api.stratumai.app https://api.stripe.com https://*.sentry.io https://cloudflareinsights.com wss: ws:; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     }
 


### PR DESCRIPTION
The strict default CSP was blocking cdn.tailwindcss.com and inline scripts on /landing-bombon.html (and would also block /landing-en.html, /landing-ar.html, /landing-ai.html). Only /landing.html had the permissive exact-match block.

Switch the exact `location =` to a regex `^/landing(-[a-z0-9]+)?\.html$` so any landing variant gets the CDN-friendly CSP. Also allow the Cloudflare Insights beacon (auto-injected when behind Cloudflare).

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
