### PR TITLE
fix(trust-gate): move indicator to bottom-right + solid bg-card

### DIFF
--- a/frontend/src/components/ui/TrustGateIndicator.tsx
+++ b/frontend/src/components/ui/TrustGateIndicator.tsx
@@ -85,13 +85,21 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
   return (
     <div
       className={cn(
-        'fixed bottom-6 left-6 z-50',
+        // Bottom-right corner, stacked above the OnboardingChatButton
+        // (bottom-4) + FeedbackWidget button (bottom-20). bottom-36
+        // clears both. Was previously bottom-left where it conflicted
+        // with the sidebar.
+        'fixed bottom-36 right-6 z-50',
         'flex flex-col gap-0 rounded-2xl',
         'transition-colors duration-300',
+        // Solid card surface — semantic token, themed correctly in
+        // dark + light. The previous `var(--bg-primary)` resolved to
+        // the page background which read as transparent over the
+        // dashboard surface.
+        'bg-card',
         className
       )}
       style={{
-        background: 'var(--bg-primary)',
         border: `2px solid ${state.color}`,
         boxShadow: `0 0 20px ${state.color}40, 0 8px 32px rgba(0, 0, 0, 0.3)`,
       }}
@@ -99,7 +107,10 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
       {/* Expanded Detail Panel */}
       {expanded && healthDetail && (
         <div className="px-4 pt-3 pb-2 space-y-2 min-w-56">
-          <div className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'rgba(255,255,255,0.4)' }}>
+          <div
+            className="text-xs font-semibold uppercase tracking-wider"
+            style={{ color: 'rgba(255,255,255,0.4)' }}
+          >
             Signal Components
           </div>
           {[
@@ -114,7 +125,12 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
                 <div
                   className="w-1.5 h-1.5 rounded-full flex-shrink-0"
                   style={{
-                    backgroundColor: comp.value >= 70 ? 'var(--landing-accent-cyan)' : comp.value >= 40 ? '#f59e0b' : '#ff6b6b',
+                    backgroundColor:
+                      comp.value >= 70
+                        ? 'var(--landing-accent-cyan)'
+                        : comp.value >= 40
+                          ? '#f59e0b'
+                          : '#ff6b6b',
                   }}
                 />
                 <span className="text-xs truncate" style={{ color: 'rgba(255,255,255,0.6)' }}>
@@ -125,7 +141,12 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
                 <span
                   className="text-xs font-mono font-medium"
                   style={{
-                    color: comp.value >= 70 ? 'var(--landing-accent-cyan)' : comp.value >= 40 ? '#f59e0b' : '#ff6b6b',
+                    color:
+                      comp.value >= 70
+                        ? 'var(--landing-accent-cyan)'
+                        : comp.value >= 40
+                          ? '#f59e0b'
+                          : '#ff6b6b',
                   }}
                 >
                   {comp.value}
@@ -138,19 +159,24 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
           ))}
           <div
             className="pt-2 mt-1 text-xs"
-            style={{ borderTop: '1px solid rgba(255,255,255,0.08)', color: 'rgba(255,255,255,0.35)' }}
+            style={{
+              borderTop: '1px solid rgba(255,255,255,0.08)',
+              color: 'rgba(255,255,255,0.35)',
+            }}
           >
-            Autopilot: {state.status === 'PASS' ? 'Enabled' : state.status === 'HOLD' ? 'Alert Only' : 'Manual Required'}
+            Autopilot:{' '}
+            {state.status === 'PASS'
+              ? 'Enabled'
+              : state.status === 'HOLD'
+                ? 'Alert Only'
+                : 'Manual Required'}
           </div>
         </div>
       )}
 
       {/* Main indicator (always visible) */}
       <button
-        className={cn(
-          'flex items-center gap-3 px-4 py-3',
-          expanded && 'border-t',
-        )}
+        className={cn('flex items-center gap-3 px-4 py-3', expanded && 'border-t')}
         style={{
           borderColor: expanded ? 'rgba(255,255,255,0.08)' : 'transparent',
         }}
@@ -161,10 +187,7 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
         {/* Pulsing status dot */}
         <div className="relative flex items-center justify-center">
           <div
-            className={cn(
-              'h-3 w-3 rounded-full',
-              isHealthy && 'animate-status-pulse'
-            )}
+            className={cn('h-3 w-3 rounded-full', isHealthy && 'animate-status-pulse')}
             style={{
               backgroundColor: state.color,
               boxShadow: `0 0 12px ${state.color}`,
@@ -186,10 +209,7 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
         {/* Status info */}
         <div className="flex flex-col items-start">
           <div className="flex items-center gap-2">
-            <span
-              className="text-sm font-semibold font-mono"
-              style={{ color: state.color }}
-            >
+            <span className="text-sm font-semibold font-mono" style={{ color: state.color }}>
               {state.score}
             </span>
             <span
@@ -202,10 +222,7 @@ export const TrustGateIndicator = memo(function TrustGateIndicator({
               {state.status}
             </span>
           </div>
-          <span
-            className="text-xs"
-            style={{ color: 'var(--landing-text-white-soft)' }}
-          >
+          <span className="text-xs" style={{ color: 'var(--landing-text-white-soft)' }}>
             Signal Health
           </span>
         </div>


### PR DESCRIPTION
The TrustGateIndicator pinned at bottom-left collided with the sidebar once expanded (Signal Components panel overflowed underneath the nav). Move it to bottom-36 right-6 — stacks cleanly above the OnboardingChatButton (bottom-4) and FeedbackWidget button (bottom-20), and well clear of the sidebar.

Also swap background from var(--bg-primary) (transparent over the dashboard surface) to bg-card semantic token, so the panel reads as a solid surface in both dark + light themes.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
