### PR TITLE
fix(dashboard): theme switch + Settings tab routing + Newsletter colors

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -986,6 +986,10 @@ function App() {
                         />
                         <Route
                           path="settings"
+                          element={<Navigate to="/dashboard/settings/profile" replace />}
+                        />
+                        <Route
+                          path="settings/:tab"
                           element={
                             <ProtectedRoute requiredRole="admin">
                               <Suspense fallback={<LoadingSpinner />}>

--- a/frontend/src/views/Settings.tsx
+++ b/frontend/src/views/Settings.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   AlertTriangle,
@@ -25,6 +25,7 @@ import {
   User,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useTheme, type Theme } from '@/components/primitives/theme/ThemeProvider';
 import apiClient from '@/api/client';
 import { useTenantStore } from '@/stores/tenantStore';
 import { useExportData, useRequestDeletion } from '@/api/hooks';
@@ -64,9 +65,29 @@ type SettingsTab =
   | 'gdpr'
   | 'trust-engine';
 
+const VALID_TABS: ReadonlySet<SettingsTab> = new Set([
+  'profile',
+  'organization',
+  'notifications',
+  'security',
+  'integrations',
+  'preferences',
+  'billing',
+  'gdpr',
+  'trust-engine',
+]);
+
 export function Settings() {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<SettingsTab>('profile');
+  const navigate = useNavigate();
+  const { tab: tabParam } = useParams<{ tab: string }>();
+
+  // Derive active tab from URL — unknown / missing falls back to profile.
+  // Tab clicks navigate to update the URL, so back/forward and direct
+  // links work the way users expect.
+  const activeTab: SettingsTab =
+    tabParam && VALID_TABS.has(tabParam as SettingsTab) ? (tabParam as SettingsTab) : 'profile';
+  const setActiveTab = (next: SettingsTab) => navigate(`/dashboard/settings/${next}`);
   const [showApiKey, setShowApiKey] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
   const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
@@ -1056,7 +1077,10 @@ function SecuritySettings({
             const setVisible = apiKey.type === 'live' ? setShowApiKey : setShowTestKey;
 
             return (
-              <div key={apiKey.id} className="p-4 rounded-xl border border-foreground/10 glass card-3d">
+              <div
+                key={apiKey.id}
+                className="p-4 rounded-xl border border-foreground/10 glass card-3d"
+              >
                 <div className="flex items-center justify-between mb-3">
                   <div className="flex items-center gap-3">
                     <h4 className="font-medium">{apiKey.name}</h4>
@@ -1651,7 +1675,10 @@ function IntegrationSettings() {
 
 function PreferenceSettings() {
   const { t, i18n } = useTranslation();
-  const [theme, setTheme] = useState('system');
+  // Wire to the ThemeProvider primitive — the topbar ThemeToggle uses
+  // the same hook, so the two stay in sync. Local useState here was a
+  // bug: it tracked a value nothing read, so clicks did nothing.
+  const { theme, setTheme } = useTheme();
   const [language, setLanguage] = useState(i18n.language);
 
   const handleLanguageChange = (lang: string) => {
@@ -1669,16 +1696,16 @@ function PreferenceSettings() {
       <div>
         <label className="text-sm font-medium mb-2 block">{t('settings.theme')}</label>
         <div className="flex gap-3">
-          {['light', 'dark', 'system'].map((t) => (
+          {(['light', 'dark', 'system'] as Theme[]).map((opt) => (
             <button
-              key={t}
-              onClick={() => setTheme(t)}
+              key={opt}
+              onClick={() => setTheme(opt)}
               className={cn(
                 'px-4 py-2 rounded-lg border transition-colors capitalize',
-                theme === t ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+                theme === opt ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
               )}
             >
-              {t}
+              {opt}
             </button>
           ))}
         </div>

--- a/frontend/src/views/newsletter/NewsletterAnalytics.tsx
+++ b/frontend/src/views/newsletter/NewsletterAnalytics.tsx
@@ -34,7 +34,7 @@ const EVENT_BADGE_STYLES: Record<string, string> = {
 };
 
 const FUNNEL_COLORS: Record<string, string> = {
-  sent: 'var(--landing-accent-cyan)',
+  sent: 'hsl(var(--primary))',
   delivered: '#3b82f6',
   opened: '#22c55e',
   clicked: '#a855f7',

--- a/frontend/src/views/newsletter/NewsletterDashboard.tsx
+++ b/frontend/src/views/newsletter/NewsletterDashboard.tsx
@@ -22,16 +22,19 @@ import {
 } from '@/api/newsletter';
 
 // ---------------------------------------------------------------------------
-// Theme constants
+// Theme constants — wired to the figma semantic tokens. The old
+// `var(--landing-*)` references were retired with the nebula-aurora
+// migration, which is why this dashboard rendered blank (every styled
+// element fell back to default browser colors).
 // ---------------------------------------------------------------------------
 const theme = {
-  primary: 'var(--landing-accent-cyan)',
-  primaryLight: 'rgba(0, 199, 190, 0.15)',
-  bgCard: 'rgba(255, 255, 255, 0.05)',
-  border: 'var(--landing-border-white-dim)',
-  textPrimary: 'rgba(245, 245, 247, 0.92)',
-  textSecondary: 'rgba(245, 245, 247, 0.6)',
-  textMuted: 'rgba(245, 245, 247, 0.35)',
+  primary: 'hsl(var(--primary))',
+  primaryLight: 'hsl(var(--primary) / 0.12)',
+  bgCard: 'hsl(var(--card))',
+  border: 'hsl(var(--border))',
+  textPrimary: 'hsl(var(--foreground))',
+  textSecondary: 'hsl(var(--muted-foreground))',
+  textMuted: 'hsl(var(--muted-foreground) / 0.6)',
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/views/newsletter/NewsletterSubscribers.tsx
+++ b/frontend/src/views/newsletter/NewsletterSubscribers.tsx
@@ -25,14 +25,17 @@ import {
 // ---------------------------------------------------------------------------
 // Theme constants
 // ---------------------------------------------------------------------------
+// Wired to the figma semantic tokens. Was `var(--landing-*)` from the
+// retired nebula-aurora theme — those vars no longer exist, leaving the
+// page rendering with default browser colors.
 const theme = {
-  primary: 'var(--landing-accent-cyan)',
-  primaryLight: 'rgba(0, 199, 190, 0.15)',
-  bgCard: 'rgba(255, 255, 255, 0.05)',
-  border: 'var(--landing-border-white-dim)',
-  textPrimary: 'rgba(245, 245, 247, 0.92)',
-  textSecondary: 'rgba(245, 245, 247, 0.6)',
-  textMuted: 'rgba(245, 245, 247, 0.35)',
+  primary: 'hsl(var(--primary))',
+  primaryLight: 'hsl(var(--primary) / 0.12)',
+  bgCard: 'hsl(var(--card))',
+  border: 'hsl(var(--border))',
+  textPrimary: 'hsl(var(--foreground))',
+  textSecondary: 'hsl(var(--muted-foreground))',
+  textMuted: 'hsl(var(--muted-foreground) / 0.6)',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Three fixes in one commit, all small targeted changes:

1. Settings → Preferences → Theme picker (Settings.tsx) The buttons updated a local useState that nothing read, so clicks did nothing. Wire to the same useTheme() hook the topbar ThemeToggle uses. Picking light / dark / system now actually swaps the theme.

2. Settings tab URL routing (Settings.tsx + App.tsx) /dashboard/settings stayed static when clicking tabs, so deep links + back/forward didn't work. Split the route into:
     /dashboard/settings        → Navigate to /settings/profile
     /dashboard/settings/:tab   → Settings reads tab from useParams()
   Tab clicks now navigate() to the new URL. Unknown tabs fall back
   to profile. VALID_TABS guard rejects garbage params.

3. Newsletter views render blank except logos (3 files) The theme constants in NewsletterDashboard / NewsletterSubscribers / NewsletterAnalytics referenced var(--landing-accent-cyan), var(--landing-border-white-dim), and rgba() values from the retired nebula-aurora palette. Those CSS variables no longer exist after the figma migration, so styled elements fell back to default browser colors (white-on-white in dark mode). Repoint to semantic tokens: hsl(var(--primary)), hsl(var(--card)), hsl(var(--border)), hsl(var(--foreground)), hsl(var(--muted-foreground)). Pages now render.

tsc clean.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
