### PR TITLE
fix(integrations): consolidate under Settings → Integrations tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -164,7 +164,8 @@ const MediaBuyerConsole = lazyWithRetry(() => import('./views/tenant/Console'));
 const SignalHub = lazyWithRetry(() => import('./views/tenant/SignalHub'));
 
 // Sprint feature views
-const Integrations = lazyWithRetry(() => import('./views/tenant/IntegrationsHub'));
+// IntegrationsHub is rendered from Settings → Integrations tab now;
+// the bare /dashboard/integrations route just 302s there.
 const GDPR = lazyWithRetry(() => import('./views/GDPR'));
 const APIKeys = lazyWithRetry(() => import('./views/APIKeys'));
 const Pacing = lazyWithRetry(() => import('./views/tenant/Pacing'));
@@ -1603,14 +1604,12 @@ function App() {
                         />
 
                         {/* Sprint Feature Routes */}
-                        {/* CRM Integrations */}
+                        {/* Integrations is the canonical surface inside Settings.
+                            Old /dashboard/integrations redirects so bookmarks
+                            and the IntegrationsHub's "Open hub" links stay valid. */}
                         <Route
                           path="integrations"
-                          element={
-                            <Suspense fallback={<LoadingSpinner />}>
-                              <Integrations />
-                            </Suspense>
-                          }
+                          element={<Navigate to="/dashboard/settings/integrations" replace />}
                         />
 
                         {/* Pacing & Forecasting */}

--- a/frontend/src/components/primitives/nav/dashboardNav.ts
+++ b/frontend/src/components/primitives/nav/dashboardNav.ts
@@ -28,10 +28,8 @@ import {
   BarChart3,
   Bell,
   Brain,
-  Cable,
   Calculator,
   Clock,
-  Code,
   Code2,
   CreditCard,
   Database,
@@ -63,8 +61,6 @@ import {
   TrendingUp,
   UserMinus,
   Users,
-  Wallet,
-  Webhook,
   Workflow,
   Zap,
 } from 'lucide-react';
@@ -399,42 +395,14 @@ const navConfig: NavGroup[] = [
     label: 'Workspace',
     items: [
       {
+        // Canonical Integrations surface lives inside Settings → Integrations
+        // (single deep-linkable URL). The hub itself surfaces buttons that
+        // navigate to Connect Platforms / Ad Accounts / CAPI Setup /
+        // Developer Portal — no need to duplicate those as sidebar children.
         label: 'Integrations',
-        href: '/dashboard/integrations',
+        href: '/dashboard/settings/integrations',
         icon: Plug,
         section: 'integrations',
-        children: [
-          {
-            label: 'Hub',
-            href: '/dashboard/integrations',
-            icon: Plug,
-            section: 'integrations',
-          },
-          {
-            label: 'Connect Platforms',
-            href: '/dashboard/campaigns/connect',
-            icon: Cable,
-            section: 'integrations',
-          },
-          {
-            label: 'Ad Accounts',
-            href: '/dashboard/campaigns/accounts',
-            icon: Wallet,
-            section: 'integrations',
-          },
-          {
-            label: 'CAPI Setup',
-            href: '/dashboard/capi-setup',
-            icon: Webhook,
-            section: 'integrations',
-          },
-          {
-            label: 'Developer Portal',
-            href: '/dashboard/developer',
-            icon: Code,
-            section: 'integrations',
-          },
-        ],
       },
       {
         label: 'WhatsApp',

--- a/frontend/src/views/Settings.tsx
+++ b/frontend/src/views/Settings.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTheme, type Theme } from '@/components/primitives/theme/ThemeProvider';
+import IntegrationsHub from '@/views/tenant/IntegrationsHub';
 import apiClient from '@/api/client';
 import { useTenantStore } from '@/stores/tenantStore';
 import { useExportData, useRequestDeletion } from '@/api/hooks';
@@ -136,7 +137,12 @@ export function Settings() {
       case 'security':
         return <SecuritySettings showApiKey={showApiKey} setShowApiKey={setShowApiKey} />;
       case 'integrations':
-        return <IntegrationSettings />;
+        // Consolidated entry point: render the unified IntegrationsHub
+        // (ad platforms / CRM / server-side tracking / outbound).
+        // Legacy analytics-tags + webhooks UI from `IntegrationSettings`
+        // is still reachable via the "Outbound" section's
+        // /dashboard/integration-hub link inside IntegrationsHub.
+        return <IntegrationsHub />;
       case 'preferences':
         return <PreferenceSettings />;
       case 'billing':
@@ -1158,7 +1164,11 @@ function SecuritySettings({
   );
 }
 
-function IntegrationSettings() {
+// Legacy analytics-tags + webhooks UI. No longer wired into the
+// Settings tabs (the integrations case renders IntegrationsHub now),
+// but kept + exported so we can resurrect specific sections (GA, GTM,
+// webhooks) into the Outbound section of IntegrationsHub later.
+export function IntegrationSettings() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [selectedPlatform, setSelectedPlatform] = useState<PlatformCredentialConfig | null>(null);


### PR DESCRIPTION
Previously the IntegrationsHub lived at /dashboard/integrations as a top-level workspace surface, while Settings → Integrations was a separate (legacy) page for analytics tags + webhooks. Two parallel entry points for the same mental model.

Consolidate to a single canonical surface:

  Sidebar Integrations    → /dashboard/settings/integrations
  /dashboard/integrations → 302 → /dashboard/settings/integrations
  Settings tab content    → renders <IntegrationsHub />

The legacy IntegrationSettings function (analytics tags / GTM / webhooks UI, ~1500 lines) is preserved + exported but no longer wired into the tab switch. We can resurrect specific sections into IntegrationsHub's Outbound block later if any are still useful.

Sidebar Integrations also collapses from a 5-child sub-nav to a single entry — Connect Platforms / Ad Accounts / CAPI Setup / Developer Portal are surfaced via buttons inside the hub itself, no need to duplicate them at the navigation level.

tsc clean.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
