### PR TITLE
feat(billing+gdpr): plan-limit gates at OAuth callbacks + GDPR activi…

### DIFF
--- a/backend/app/api/v1/endpoints/audience_sync.py
+++ b/backend/app/api/v1/endpoints/audience_sync.py
@@ -193,6 +193,20 @@ async def create_platform_audience(
             detail=f"Invalid platform. Supported: {[p.value for p in SyncPlatform]}",
         )
 
+    # Plan limit check before creating a new platform audience.
+    # AUDIENCE_SYNC_PLATFORMS caps how many distinct ad-platform sync
+    # destinations a tenant can have active. Raises HTTP 402 with the
+    # structured upgrade payload when the tenant is at or above their
+    # plan's audience-sync cap.
+    from app.services.tenant.limits import LimitType, check_tenant_limit
+
+    await check_tenant_limit(
+        db,
+        tenant_id,
+        LimitType.AUDIENCE_SYNC_PLATFORMS,
+        raise_on_exceeded=True,
+    )
+
     service = AudienceSyncService(db, tenant_id)
 
     try:

--- a/backend/app/api/v1/endpoints/oauth.py
+++ b/backend/app/api/v1/endpoints/oauth.py
@@ -686,6 +686,20 @@ async def connect_ad_accounts(
             existing.last_synced_at = datetime.now(UTC)
             account = existing
         else:
+            # Plan limit check before creating a new TenantAdAccount.
+            # Re-evaluate per row so multi-account selections don't slip
+            # past the gate. Raises HTTP 402 with the structured upgrade
+            # payload (current/max/suggested_tier) when the tenant is at
+            # or above their plan's ad-account cap.
+            from app.services.tenant.limits import LimitType, check_tenant_limit
+
+            await check_tenant_limit(
+                db,
+                current_user.tenant_id,
+                LimitType.AD_ACCOUNTS,
+                raise_on_exceeded=True,
+            )
+
             # Create new
             account = TenantAdAccount(
                 tenant_id=current_user.tenant_id,

--- a/frontend/src/views/GDPR.tsx
+++ b/frontend/src/views/GDPR.tsx
@@ -1,11 +1,12 @@
 /**
  * GDPR — Data subject rights page at /dashboard/gdpr.
  *
- * Three sections, all backed by existing hooks in `@/api/gdpr`:
+ * Four sections, all backed by existing hooks in `@/api/gdpr`:
  *
- *   1. Export my data       — useExportHistory + useExportData
- *   2. Right to be forgotten — useRequestDeletion (with ConfirmDrawer)
- *   3. Consent records      — useConsentRecords + useUpdateConsent
+ *   1. Export my data        — useExportHistory + useExportData
+ *   2. Consent records       — useConsentRecords + useUpdateConsent
+ *   3. Right to be forgotten — useRequestDeletion (with ConfirmDrawer)
+ *   4. Activity log          — useAuditLogs with action filter
  *
  * Admin+ in operator dashboard. The B2B compliance angle: agencies
  * with EU clients need to be able to honor data-subject requests on
@@ -19,6 +20,9 @@ import {
   useRequestDeletion,
   useConsentRecords,
   useUpdateConsent,
+  useAuditLogs,
+  type AuditAction,
+  type AuditLog,
   type DataExportRequest,
   type ConsentRecord,
 } from '@/api/gdpr';
@@ -39,6 +43,12 @@ export default function GDPR() {
   const [format, setFormat] = useState<'json' | 'csv'>('json');
   const [deletionOpen, setDeletionOpen] = useState(false);
   const [deletionConfirm, setDeletionConfirm] = useState('');
+  const [actionFilter, setActionFilter] = useState<AuditAction | ''>('');
+
+  const auditLogs = useAuditLogs({
+    action: actionFilter || undefined,
+    limit: 50,
+  });
 
   const handleExport = () => {
     exportMutation.mutate(format);
@@ -209,6 +219,56 @@ export default function GDPR() {
         </div>
       </Card>
 
+      {/* 4. Activity log */}
+      <Card>
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+              <FileDown className="w-4 h-4 text-primary" />
+              Activity log
+            </h2>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              The 50 most recent actions on data we hold about you. Surfaced here so compliance
+              teams can verify access patterns without filing a ticket.
+            </p>
+          </div>
+          <select
+            value={actionFilter}
+            onChange={(e) => setActionFilter((e.target.value as AuditAction | '') || '')}
+            className={cn(
+              'h-9 px-3 rounded-lg bg-card border border-border text-foreground text-sm',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              'min-w-44'
+            )}
+          >
+            <option value="">All actions</option>
+            <option value="login">Login</option>
+            <option value="logout">Logout</option>
+            <option value="data_export">Data export</option>
+            <option value="data_delete">Data delete</option>
+            <option value="consent_update">Consent update</option>
+            <option value="user_create">User create</option>
+            <option value="user_update">User update</option>
+            <option value="user_delete">User delete</option>
+            <option value="settings_update">Settings update</option>
+          </select>
+        </div>
+
+        <DataTable<AuditLog>
+          data={auditLogs.data?.items ?? []}
+          columns={AUDIT_COLUMNS}
+          loading={auditLogs.isPending}
+          error={auditLogs.error?.message}
+          emptyMessage={
+            actionFilter
+              ? `No ${actionFilter.replace(/_/g, ' ')} events in the recent window.`
+              : 'No activity recorded yet.'
+          }
+          rowKey={(r) => r.id}
+          ariaLabel="Recent audit log entries"
+        />
+      </Card>
+
       {/* Deletion confirmation */}
       <ConfirmDrawer
         open={deletionOpen}
@@ -247,6 +307,59 @@ export default function GDPR() {
     </div>
   );
 }
+
+const AUDIT_COLUMNS: DataTableColumn<AuditLog>[] = [
+  {
+    id: 'time',
+    header: 'When',
+    cell: (r) => (
+      <span className="text-xs font-mono tabular-nums text-muted-foreground">
+        {formatDate(r.createdAt)}
+      </span>
+    ),
+    sortable: true,
+    sortAccessor: (r) => new Date(r.createdAt).getTime(),
+  },
+  {
+    id: 'user',
+    header: 'Actor',
+    cell: (r) => (
+      <span className="text-sm text-foreground truncate">{r.userName || `#${r.userId}`}</span>
+    ),
+    sortable: true,
+    sortAccessor: (r) => r.userName ?? '',
+  },
+  {
+    id: 'action',
+    header: 'Action',
+    cell: (r) => (
+      <span className="text-xs font-mono uppercase tracking-wider text-muted-foreground">
+        {r.action.replace(/_/g, ' ')}
+      </span>
+    ),
+    sortable: true,
+    sortAccessor: (r) => r.action,
+  },
+  {
+    id: 'resource',
+    header: 'Resource',
+    cell: (r) => (
+      <span className="text-xs font-mono text-foreground/80 truncate">
+        {r.resourceType}
+        {r.resourceId ? <span className="text-muted-foreground"> · {r.resourceId}</span> : null}
+      </span>
+    ),
+    hideOnMobile: true,
+  },
+  {
+    id: 'ip',
+    header: 'IP',
+    cell: (r) => (
+      <span className="text-xs font-mono text-muted-foreground">{r.ipAddress || '—'}</span>
+    ),
+    hideOnMobile: true,
+  },
+];
 
 const EXPORT_COLUMNS: DataTableColumn<DataExportRequest>[] = [
   {


### PR DESCRIPTION
…ty log

Item 7 — Plan-limit enforcement at OAuth account-connect

Two paths that previously bypassed the tenant-limit service now gate through it before persisting anything new:

  POST /oauth/{platform}/accounts/connect
    Inside the per-account loop, calls
    check_tenant_limit(LimitType.AD_ACCOUNTS, raise_on_exceeded=True)
    before db.add(TenantAdAccount(...)). Re-evaluates per row so
    multi-account selections can't slip past the cap. Raises HTTP 402
    with the structured upgrade payload (current/max/suggested_tier)
    when the tenant is at or above their plan's ad-account limit.

  POST /audience_sync/audiences
    Calls check_tenant_limit(LimitType.AUDIENCE_SYNC_PLATFORMS,
    raise_on_exceeded=True) before AudienceSyncService.create_platform_audience.
    Same 402 flow when the tenant is at or above their cap.

Closes the deferred limit-enforcement gap from the original billing-arc.

Item 15 — GDPR Activity log section

Adds a fourth section to /dashboard/gdpr that surfaces the most recent 50 audit-log entries via useAuditLogs from @/api/gdpr. Action-type dropdown filter (login / logout / data_export / data_delete / consent_update / user_create+update+delete / settings_update). Compliance teams can now verify access patterns directly from the data-rights page instead of filing a ticket.

Columns: when, actor, action, resource (type · id), ip. Sortable on when / actor / action.

Skipped this round (with reasons):

  Item 8 (cross-tenant anomalies server rollup) — current client-side
    fan-out via useQueries on /console/anomalies works for typical
    scale (~50 tenants). A real server rollup needs extracting ~150
    lines of detection logic from the existing /insights/anomalies
    handler. Out of scope for this batch.

  Items 10 / 11 / 12 (Newsletter / WhatsApp / EmbedWidgets cosmetic
    theme sweep) — ~220 hits, all bg-gray-XXX / text-gray-XXX classes
    that still RENDER correctly, just don't theme-swap. Not real
    breakage. Defer until a designer pass is scheduled to avoid
    accidental visual regressions.

  Item 16 (kill legacy IntegrationSettings) — already preserved as
    an exported function that's not wired. Decision is "keep" — we
    may resurrect specific sections (GA tags / GTM / webhooks) into
    IntegrationsHub's Outbound block later.

  Item 19 (full vitest re-run) — earlier targeted suites pass (nav
    primitives 17/17, smoke tests 7/7); full-suite run hung in
    background, the pre-existing ProtectedRoute.test.tsx OOM is the
    likely cause. Not introduced by this branch.

tsc clean. Backend syntax checks pass on both modified endpoints.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
