### PR TITLE
feat(emq): surface qa_fixes step-by-step guide in EMQDiagnostics

### DIFF
--- a/frontend/src/api/qaFixes.ts
+++ b/frontend/src/api/qaFixes.ts
@@ -1,0 +1,70 @@
+/**
+ * QA Fixes — wraps the /qa-fixes router.
+ *
+ * Complements emqV2: emqV2 ships the priority-queue playbook (status,
+ * owner, estimatedImpact); qa_fixes ships the step-by-step instructions
+ * for each fix and an application history. Surfaced inside EMQDiagnostics
+ * as the "how to do it" companion to the emq_v2 task list.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import api from './client';
+
+export interface QAFixPlaybookItem {
+  id: string;
+  title: string;
+  description: string;
+  priority: 'critical' | 'high' | 'medium' | 'low';
+  estimated_impact: number;
+  platform: string | null;
+  status: 'pending' | 'in_progress' | 'completed';
+  steps: string[];
+}
+
+export interface QAFixPlaybookResponse {
+  items: QAFixPlaybookItem[];
+  total: number;
+  estimated_total_impact: number;
+}
+
+export interface QAFixHistoryEntry {
+  id: string;
+  timestamp: string | null;
+  action_type: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  details: Record<string, unknown> | null;
+}
+
+export interface QAFixHistoryResponse {
+  history: QAFixHistoryEntry[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export function useQAFixesPlaybook(tenantId: number) {
+  return useQuery({
+    queryKey: ['qa-fixes', 'playbook', tenantId],
+    queryFn: async () => {
+      const res = await api.get<QAFixPlaybookResponse>(`/qa-fixes/${tenantId}/playbook`);
+      return res.data;
+    },
+    enabled: tenantId > 0,
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useQAFixesHistory(tenantId: number, limit = 10) {
+  return useQuery({
+    queryKey: ['qa-fixes', 'history', tenantId, limit],
+    queryFn: async () => {
+      const res = await api.get<QAFixHistoryResponse>(
+        `/qa-fixes/${tenantId}/history?limit=${limit}`
+      );
+      return res.data;
+    },
+    enabled: tenantId > 0,
+    staleTime: 60 * 1000,
+  });
+}

--- a/frontend/src/views/EMQDiagnostics.tsx
+++ b/frontend/src/views/EMQDiagnostics.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 
 import { useTenantStore, selectTenantId } from '@/stores/tenantStore';
+import { useQAFixesPlaybook, useQAFixesHistory, type QAFixPlaybookItem } from '@/api/qaFixes';
 import {
   useEmqScore,
   useConfidence,
@@ -328,6 +329,8 @@ export default function EMQDiagnostics() {
         </ul>
       </Card>
 
+      <FixGuideSection tenantId={tenantId} />
+
       <Card className="p-6">
         <header className="mb-4 flex items-center justify-between">
           <h2 className="font-mono text-sm uppercase tracking-wider text-muted-foreground">
@@ -351,5 +354,104 @@ export default function EMQDiagnostics() {
         )}
       </Card>
     </div>
+  );
+}
+
+function FixGuideSection({ tenantId }: { tenantId: number }) {
+  const playbookQuery = useQAFixesPlaybook(tenantId);
+  const historyQuery = useQAFixesHistory(tenantId, 5);
+  const items: QAFixPlaybookItem[] = playbookQuery.data?.items ?? [];
+  const history = historyQuery.data?.history ?? [];
+
+  return (
+    <Card className="p-6 space-y-4">
+      <header className="flex items-center justify-between">
+        <h2 className="font-mono text-sm uppercase tracking-wider text-muted-foreground">
+          Step-by-step fix guide
+        </h2>
+        {playbookQuery.data?.estimated_total_impact != null && (
+          <span className="font-mono text-xs text-muted-foreground">
+            +{playbookQuery.data.estimated_total_impact.toFixed(1)} EMQ available
+          </span>
+        )}
+      </header>
+
+      <ul className="space-y-3">
+        {items.map((it) => (
+          <li
+            key={it.id}
+            className="rounded-xl border border-border bg-muted/40 p-4"
+          >
+            <details>
+              <summary className="cursor-pointer list-none flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <StatusPill variant={PRIORITY_VARIANT[it.priority]} size="sm">
+                      {it.priority}
+                    </StatusPill>
+                    {it.platform && (
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {it.platform}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm font-medium">{it.title}</p>
+                  <p className="text-sm text-muted-foreground">{it.description}</p>
+                </div>
+                <span className="font-mono text-xs text-muted-foreground shrink-0">
+                  +{it.estimated_impact.toFixed(1)} EMQ
+                </span>
+              </summary>
+              {it.steps.length > 0 && (
+                <ol className="mt-3 space-y-1.5 border-t border-border/50 pt-3 text-sm text-foreground">
+                  {it.steps.map((step, idx) => (
+                    <li key={idx} className="flex gap-2">
+                      <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                        {idx + 1}.
+                      </span>
+                      <span>{step}</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </details>
+          </li>
+        ))}
+        {!playbookQuery.isLoading && items.length === 0 && (
+          <li className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+            No step-by-step fixes available — connect a platform to detect issues.
+          </li>
+        )}
+      </ul>
+
+      {history.length > 0 && (
+        <details className="rounded-xl border border-border bg-muted/40 p-4">
+          <summary className="cursor-pointer text-sm font-medium">
+            Recent fix activity
+            <span className="ml-2 font-mono text-xs text-muted-foreground">
+              {historyQuery.data?.total ?? history.length}
+            </span>
+          </summary>
+          <ul className="mt-3 space-y-1.5 text-sm">
+            {history.map((h) => (
+              <li
+                key={h.id}
+                className="flex items-baseline justify-between gap-2 text-muted-foreground"
+              >
+                <span>
+                  <span className="font-mono text-xs">{h.action_type}</span>
+                  {h.entity_id && ` · ${h.entity_id}`}
+                </span>
+                {h.timestamp && (
+                  <span className="font-mono text-xs tabular-nums">
+                    {new Date(h.timestamp).toLocaleString()}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </Card>
   );
 }


### PR DESCRIPTION
Investigation: qa_fixes is NOT redundant with emq_v2 — it uniquely provides multi-step instructions per fix (steps[]) and a fix- application history backed by enforcement_audit_logs. emq_v2 covers status / priority / autopilot. Both are operator-relevant; surfacing qa_fixes as the "how to do it" companion to emq_v2's task queue.

Adds:
- frontend/src/api/qaFixes.ts — useQAFixesPlaybook, useQAFixesHistory hooks over /qa-fixes/{id}/playbook and /history.
- New <FixGuideSection /> in EMQDiagnostics: collapsible per-item step-by-step instructions ordered by estimated impact, plus a "Recent fix activity" details element sourced from the audit log.

Suite: 986/986 tests across 63 files green.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
