### PR TITLE
fix(views): repair broken merge in three analytics views

### DIFF
--- a/frontend/src/views/CohortAnalysis.tsx
+++ b/frontend/src/views/CohortAnalysis.tsx
@@ -74,7 +74,6 @@ export default function CohortAnalysis() {
 
   return (
     <div className="min-h-screen bg-background text-foreground p-6">
-    <div className="min-h-screen bg-background text-white p-6">
       <div className="max-w-7xl mx-auto">
         <header className="mb-8">
           <h1 className="text-3xl font-bold flex items-center gap-3">
@@ -119,19 +118,6 @@ export default function CohortAnalysis() {
               <option value="monthly" className="bg-card">
                 Monthly
               </option>
-            <label className="block text-sm text-gray-400 mb-1">Metric</label>
-            <select value={metric} onChange={(e) => setMetric(e.target.value)} className="bg-foreground/[0.03] border border-foreground/10 rounded-lg px-3 py-2 text-white">
-              <option value="retention" className="bg-card">Retention</option>
-              <option value="revenue" className="bg-card">Revenue</option>
-              <option value="conversions" className="bg-card">Conversions</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Period</label>
-            <select value={period} onChange={(e) => setPeriod(e.target.value)} className="bg-foreground/[0.03] border border-foreground/10 rounded-lg px-3 py-2 text-white">
-              <option value="daily" className="bg-card">Daily</option>
-              <option value="weekly" className="bg-card">Weekly</option>
-              <option value="monthly" className="bg-card">Monthly</option>
             </select>
           </div>
           <div className="flex gap-3">
@@ -250,8 +236,6 @@ export default function CohortAnalysis() {
                           className="absolute bottom-0 left-0 right-0 bg-primary/40 rounded-t"
                           style={{ height: '100%' }}
                         />
-                      <div className="w-full bg-foreground/10 rounded-t relative" style={{ height: `${Math.min(v * 1.5, 100)}%` }}>
-                        <div className="absolute bottom-0 left-0 right-0 bg-primary/40 rounded-t" style={{ height: '100%' }} />
                       </div>
                       <span className="text-xs text-muted-foreground">P{i}</span>
                       <span className="text-xs text-foreground">{v.toFixed(1)}</span>

--- a/frontend/src/views/FunnelAnalysis.tsx
+++ b/frontend/src/views/FunnelAnalysis.tsx
@@ -85,7 +85,6 @@ export default function FunnelAnalysis() {
 
   return (
     <div className="min-h-screen bg-background text-foreground p-6">
-    <div className="min-h-screen bg-background text-white p-6">
       <div className="max-w-6xl mx-auto">
         <header className="mb-8">
           <h1 className="text-3xl font-bold flex items-center gap-3">
@@ -148,10 +147,6 @@ export default function FunnelAnalysis() {
                     </option>
                   )
                 )}
-                <option value="" className="bg-card">Select event...</option>
-                {['impression', 'click', 'landing', 'add_to_cart', 'conversion', 'purchase'].map((opt) => (
-                  <option key={opt} value={opt} className="bg-card">{opt}</option>
-                ))}
               </select>
               {steps.length > 2 && (
                 <button
@@ -168,7 +163,6 @@ export default function FunnelAnalysis() {
             onClick={addStep}
             className="text-sm text-primary flex items-center gap-1 mt-2 hover:underline"
           >
-          <button onClick={addStep} className="text-sm text-primary flex items-center gap-1 mt-2 hover:underline">
             <PlusIcon className="w-4 h-4" /> Add step
           </button>
 
@@ -222,7 +216,6 @@ export default function FunnelAnalysis() {
                 </div>
               </div>
 
-              {/* Funnel Bars */}
               <div className="space-y-4">
                 {result.steps.map((step, i) => {
                   const maxCount = result.steps[0]?.count || 1;
@@ -244,9 +237,6 @@ export default function FunnelAnalysis() {
                               : i === result.steps.length - 1
                                 ? 'bg-success'
                                 : 'bg-info'
-                            i === 0 ? 'bg-primary' :
-                            i === result.steps.length - 1 ? 'bg-green-400' :
-                            'bg-primary'
                           )}
                           style={{ width: `${widthPct}%` }}
                         >

--- a/frontend/src/views/SQLEditor.tsx
+++ b/frontend/src/views/SQLEditor.tsx
@@ -68,7 +68,6 @@ export default function SQLEditor() {
 
   return (
     <div className="min-h-screen bg-background text-foreground p-6">
-    <div className="min-h-screen bg-background text-white p-6">
       <div className="max-w-7xl mx-auto">
         <header className="mb-8">
           <h1 className="text-3xl font-bold flex items-center gap-3">
@@ -81,7 +80,6 @@ export default function SQLEditor() {
         </header>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left: Editor */}
           <div className="lg:col-span-2 space-y-4">
             <div className={PANEL_SURFACE}>
               <div className="flex items-center justify-between mb-2">
@@ -97,7 +95,6 @@ export default function SQLEditor() {
                       <option key={n} value={n} className="bg-card">
                         {n}
                       </option>
-                      <option key={n} value={n} className="bg-card">{n}</option>
                     ))}
                   </select>
                 </div>
@@ -157,7 +154,6 @@ export default function SQLEditor() {
                     onClick={() =>
                       navigator.clipboard.writeText(JSON.stringify(result.rows, null, 2))
                     }
-                    onClick={() => navigator.clipboard.writeText(JSON.stringify(result.rows, null, 2))}
                     className="text-xs text-primary hover:underline flex items-center gap-1"
                   >
                     <DocumentDuplicateIcon className="w-3 h-3" /> Copy JSON
@@ -197,7 +193,6 @@ export default function SQLEditor() {
             )}
           </div>
 
-          {/* Right: Sample Queries */}
           <div className="space-y-4">
             <div className={PANEL_SURFACE}>
               <h3 className="text-sm font-medium text-foreground mb-3">Sample Queries</h3>


### PR DESCRIPTION
PR #263 (loading-state-audit) merged with an unresolved conflict against PR #262 (dashboard-hex-sweep) — both touched the same three files and the GitHub merge produced files with duplicated JSX (two <div className="min-h-screen ..."> tags side by side, duplicated <option>, etc.). main was failing tsc --noEmit.

Rewrites CohortAnalysis, FunnelAnalysis, and SQLEditor with the intended post-PR-263 state: semantic theme tokens + loading / empty / error states, no leftover hex literals.

Suite: 987/987 tests across 63 files green; tsc clean.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
