### PR TITLE
feat(copilot): RAG foundation — pgvector + doc indexing (Phase D PR1)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -301,6 +301,30 @@ class Settings(BaseSettings):
     )
 
     # -------------------------------------------------------------------------
+    # Copilot RAG (PR1: indexing only — bridge wiring lands in PR2)
+    # -------------------------------------------------------------------------
+    copilot_rag_enabled: bool = Field(
+        default=False,
+        description="Retrieve relevant Stratum docs and inject into the Copilot prompt",
+    )
+    openai_api_key: Optional[str] = Field(
+        default=None,
+        description="OpenAI key — required when copilot_rag_enabled=True (text-embedding-3-small)",
+    )
+    copilot_rag_embedding_model: str = Field(
+        default="text-embedding-3-small",
+        description="OpenAI embedding model. 1536-dim, must match the migration's vector(1536) column",
+    )
+    copilot_rag_top_k: int = Field(
+        default=4,
+        description="How many doc chunks to retrieve per query before sending to Claude",
+    )
+    copilot_rag_chunk_chars: int = Field(
+        default=1200,
+        description="Target characters per chunk during indexing (paragraph-boundary aware)",
+    )
+
+    # -------------------------------------------------------------------------
     # Stripe Payments Configuration
     # -------------------------------------------------------------------------
     stripe_secret_key: Optional[str] = Field(default=None, description="Stripe secret API key")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -154,6 +154,7 @@ from app.models.launch_readiness import (
     LaunchReadinessItemState,
     LaunchReadinessEvent,
 )
+from app.models.copilot_doc import CopilotDocChunk
 
 __all__ = [
     "APIKey",
@@ -189,6 +190,7 @@ __all__ = [
     "ChannelInteraction",
     "Client",
     "ClientAssignment",
+    "CopilotDocChunk",
     "ClientRequest",
     # Client (Agency → Brand)
     "ClientRequestStatus",

--- a/backend/app/models/copilot_doc.py
+++ b/backend/app/models/copilot_doc.py
@@ -1,0 +1,61 @@
+# =============================================================================
+# Stratum AI - Copilot Doc Chunk Model
+# =============================================================================
+"""
+SQLAlchemy model for `copilot_doc_chunks` — chunked Stratum docs with
+OpenAI text-embedding-3-small embeddings used by the RAG bridge.
+
+Foundation only: this model declares the columns; retrieval lives in
+`app.services.agents.doc_index`. The bridge stays off until the
+COPILOT_RAG_ENABLED feature flag flips.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy import BigInteger, DateTime, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base_class import Base
+
+
+class CopilotDocChunk(Base):
+    """One chunk of indexed Stratum documentation."""
+
+    __tablename__ = "copilot_doc_chunks"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    source_path: Mapped[str] = mapped_column(Text, nullable=False)
+    chunk_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # The vector column is created via raw DDL in migration 049 because
+    # SQLAlchemy core doesn't have a first-class pgvector type without the
+    # pgvector-python dialect plugin. We touch the column from Python only
+    # via raw SQL in `app.services.agents.doc_index`, so an ORM mapping
+    # isn't required — but we declare it as Text so SELECT * round-trips
+    # don't error. Don't write to it via ORM; use the raw SQL helpers.
+    embedding: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    chunk_metadata: Mapped[Dict[str, Any]] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict
+    )
+    indexed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        Index(
+            "copilot_doc_chunks_source_chunk_uq",
+            "source_path",
+            "chunk_index",
+            unique=True,
+        ),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover — debugging only
+        return (
+            f"<CopilotDocChunk id={self.id} source={self.source_path!r} "
+            f"chunk={self.chunk_index}>"
+        )

--- a/backend/app/scripts/index_copilot_docs.py
+++ b/backend/app/scripts/index_copilot_docs.py
@@ -1,0 +1,137 @@
+# =============================================================================
+# Stratum AI - Copilot Doc Indexer (CLI)
+# =============================================================================
+"""
+Re-index the curated Stratum docs corpus into `copilot_doc_chunks`.
+
+Usage:
+    python -m app.scripts.index_copilot_docs                # all curated docs
+    python -m app.scripts.index_copilot_docs path/to/file.md ...  # specific files
+    python -m app.scripts.index_copilot_docs --dry-run      # chunk + count, no embed/write
+
+Run from the `backend/` directory after `make migrate` so the
+`copilot_doc_chunks` table exists. Requires `OPENAI_API_KEY` in the
+env unless `--dry-run` is set.
+
+Idempotent on re-run; the unique constraint on (source_path,
+chunk_index) means re-running just refreshes existing rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import List
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.db.session import async_session_factory
+from app.services.agents.doc_index import (
+    CURATED_GLOBS,
+    RagDisabledError,
+    chunk_markdown,
+    find_corpus_files,
+    reindex_file,
+)
+
+logger = get_logger(__name__)
+
+
+# Repo root, two levels up from this file (backend/app/scripts/this.py -> backend/.. -> repo)
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _resolve_targets(args: List[str]) -> List[Path]:
+    """Either explicit paths or the curated corpus."""
+    if args:
+        out: List[Path] = []
+        for arg in args:
+            p = Path(arg)
+            if not p.is_absolute():
+                p = REPO_ROOT / p
+            if p.is_file() and p.suffix == ".md":
+                out.append(p)
+            elif p.is_dir():
+                out.extend(sorted(p.rglob("*.md")))
+            else:
+                logger.warning("indexer_skipping_invalid_path", path=str(p))
+        return out
+    return find_corpus_files(REPO_ROOT)
+
+
+async def _run_dry(files: List[Path]) -> None:
+    total_chunks = 0
+    for path in files:
+        text_content = path.read_text(encoding="utf-8")
+        chunks = chunk_markdown(
+            source_path=str(path.relative_to(REPO_ROOT)),
+            text_content=text_content,
+            target_chars=settings.copilot_rag_chunk_chars,
+        )
+        total_chunks += len(chunks)
+        print(f"  {path.relative_to(REPO_ROOT)}  →  {len(chunks)} chunks")
+    print(f"\nTotal: {len(files)} files, {total_chunks} chunks (no embeddings written).")
+
+
+async def _run_index(files: List[Path]) -> None:
+    if not settings.openai_api_key:
+        raise RagDisabledError(
+            "OPENAI_API_KEY is not set — set it in the environment or use --dry-run"
+        )
+
+    written = 0
+    async with async_session_factory() as session:
+        async with session.begin():
+            for path in files:
+                rel = str(path.relative_to(REPO_ROOT))
+                text_content = path.read_text(encoding="utf-8")
+                count = await reindex_file(session, rel, text_content)
+                print(f"  {rel}  →  {count} chunks")
+                written += count
+    print(f"\nIndexed {written} chunks across {len(files)} files.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-index Stratum docs for the Copilot RAG bridge."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Specific .md files or directories to index. Defaults to the curated corpus.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Chunk and report sizes without calling OpenAI or writing to the database.",
+    )
+    parsed = parser.parse_args()
+
+    files = _resolve_targets(parsed.paths)
+    if not files:
+        if parsed.paths:
+            print("No matching .md files found.", file=sys.stderr)
+        else:
+            print(
+                "Curated corpus matched zero files. Verify globs in doc_index.CURATED_GLOBS:\n  "
+                + "\n  ".join(CURATED_GLOBS),
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"Target: {len(files)} markdown file(s).")
+    if parsed.dry_run:
+        asyncio.run(_run_dry(files))
+        return 0
+    try:
+        asyncio.run(_run_index(files))
+    except RagDisabledError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/services/agents/doc_index.py
+++ b/backend/app/services/agents/doc_index.py
@@ -1,0 +1,473 @@
+# =============================================================================
+# Stratum AI - Copilot Doc Index (Phase D foundation)
+# =============================================================================
+"""
+Indexing + retrieval helpers for the Copilot RAG bridge.
+
+Three responsibilities:
+
+1. **Chunk** Stratum markdown docs at paragraph boundaries with a
+   target character budget (`copilot_rag_chunk_chars`). Headings are
+   carried into chunk metadata so retrieval can show the operator
+   *which doc, which section* a citation came from.
+
+2. **Embed** chunks via OpenAI `text-embedding-3-small` (1536-dim) and
+   upsert into `copilot_doc_chunks`. Idempotent on re-index — the
+   unique constraint on (source_path, chunk_index) means re-running
+   the indexer just refreshes existing rows.
+
+3. **Retrieve** the top-K nearest chunks to a query embedding using
+   pgvector's cosine-distance ANN index. Returns content + citation
+   metadata. Used by `copilot_llm.generate_llm_message` (PR2).
+
+Failure semantics: every public function tolerates a missing
+`OPENAI_API_KEY` by raising `RagDisabledError`, which the bridge can
+catch and fall back to non-RAG behavior. No user-facing surface
+should rely on this without checking `settings.copilot_rag_enabled`
+first.
+
+Curated corpus (this PR1):
+    docs/00-overview/**/*.md
+    docs/04-features/**/*.md
+    docs/07-user-guide/**/*.md
+    docs/architecture/trust-engine.md
+    docs/architecture/system-architecture.md
+    docs/00-overview/glossary.md
+    docs/03-frontend/figma-theme.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# =============================================================================
+# Errors
+# =============================================================================
+
+
+class RagDisabledError(RuntimeError):
+    """Raised when RAG is requested but the OPENAI_API_KEY is missing."""
+
+
+# =============================================================================
+# Chunking
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class DocChunk:
+    """A single chunked passage of a markdown doc, ready to embed."""
+
+    source_path: str
+    chunk_index: int
+    content: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$", re.MULTILINE)
+
+
+def _walk_headings(text_content: str) -> List[Dict[str, Any]]:
+    """Return [(char_offset, level, title), ...] for every markdown heading."""
+    return [
+        {"offset": m.start(), "level": len(m.group(1)), "title": m.group(2)}
+        for m in _HEADING_RE.finditer(text_content)
+    ]
+
+
+def _heading_path_for_offset(headings: Sequence[Dict[str, Any]], offset: int) -> List[str]:
+    """Find the active heading hierarchy at a given character offset."""
+    stack: List[Dict[str, Any]] = []
+    for h in headings:
+        if h["offset"] > offset:
+            break
+        # Pop deeper-or-equal levels — sibling headings replace each other.
+        while stack and stack[-1]["level"] >= h["level"]:
+            stack.pop()
+        stack.append(h)
+    return [h["title"] for h in stack]
+
+
+def chunk_markdown(
+    source_path: str,
+    text_content: str,
+    target_chars: int = 1200,
+) -> List[DocChunk]:
+    """
+    Split a markdown file into chunks at paragraph boundaries.
+
+    A chunk is grown by accumulating paragraphs (separated by blank
+    lines) until the next paragraph would push it past `target_chars`.
+    Code fences are kept intact — they don't get split mid-block.
+
+    The first chunk includes any frontmatter / preface above the first
+    heading. Each chunk's metadata records the active heading path at
+    its starting offset so retrieval can show "Trust Engine » Phases".
+    """
+    if not text_content.strip():
+        return []
+
+    headings = _walk_headings(text_content)
+    paragraphs = _split_paragraphs(text_content)
+
+    chunks: List[DocChunk] = []
+    buf: List[str] = []
+    buf_len = 0
+    chunk_offset = 0  # char offset of the first paragraph in `buf`
+    current_offset = 0  # advances as we consume paragraphs
+
+    def flush() -> None:
+        nonlocal buf, buf_len, chunk_offset
+        if not buf:
+            return
+        content = "\n\n".join(buf).strip()
+        if not content:
+            buf = []
+            buf_len = 0
+            return
+        heading_path = _heading_path_for_offset(headings, chunk_offset)
+        title = heading_path[-1] if heading_path else Path(source_path).stem
+        chunks.append(
+            DocChunk(
+                source_path=source_path,
+                chunk_index=len(chunks),
+                content=content,
+                metadata={
+                    "title": title,
+                    "heading_path": heading_path,
+                    "char_offset": chunk_offset,
+                    "char_length": len(content),
+                },
+            )
+        )
+        buf = []
+        buf_len = 0
+
+    for paragraph, paragraph_offset in paragraphs:
+        p_len = len(paragraph)
+        if buf and buf_len + p_len + 2 > target_chars:
+            flush()
+            chunk_offset = paragraph_offset
+        if not buf:
+            chunk_offset = paragraph_offset
+        buf.append(paragraph)
+        buf_len += p_len + 2
+        current_offset = paragraph_offset + p_len
+
+    flush()
+    return chunks
+
+
+def _split_paragraphs(text_content: str) -> List[tuple[str, int]]:
+    """
+    Yield (paragraph, char_offset) pairs. Code fences (``` blocks) are
+    treated as a single indivisible paragraph regardless of internal
+    blank lines.
+    """
+    out: List[tuple[str, int]] = []
+    pos = 0
+    fence_re = re.compile(r"^```", re.MULTILINE)
+    while pos < len(text_content):
+        # Detect a code fence at the next non-blank line.
+        rest = text_content[pos:]
+        leading_ws = re.match(r"\A\s*", rest)
+        ws_len = len(leading_ws.group(0)) if leading_ws else 0
+        body_pos = pos + ws_len
+        if body_pos >= len(text_content):
+            break
+
+        if text_content[body_pos:body_pos + 3] == "```":
+            # Find the matching closing fence on its own line.
+            close = fence_re.search(text_content, body_pos + 3)
+            if close is None:
+                # Unterminated fence — treat the rest as one paragraph.
+                out.append((text_content[body_pos:].rstrip(), body_pos))
+                break
+            end = close.end()
+            # Consume to end-of-line of the closing fence.
+            newline = text_content.find("\n", end)
+            if newline == -1:
+                newline = len(text_content)
+            out.append((text_content[body_pos:newline].rstrip(), body_pos))
+            pos = newline + 1
+            continue
+
+        # Plain paragraph: read until the next blank line.
+        next_blank = re.search(r"\n\s*\n", text_content[body_pos:])
+        if next_blank is None:
+            paragraph = text_content[body_pos:].rstrip()
+            if paragraph:
+                out.append((paragraph, body_pos))
+            break
+        paragraph_end = body_pos + next_blank.start()
+        paragraph = text_content[body_pos:paragraph_end].rstrip()
+        if paragraph:
+            out.append((paragraph, body_pos))
+        pos = body_pos + next_blank.end()
+    return out
+
+
+# =============================================================================
+# Curated corpus
+# =============================================================================
+
+
+CURATED_GLOBS: tuple[str, ...] = (
+    "docs/00-overview/**/*.md",
+    "docs/04-features/**/*.md",
+    "docs/07-user-guide/**/*.md",
+    "docs/architecture/trust-engine.md",
+    "docs/architecture/system-architecture.md",
+    "docs/03-frontend/figma-theme.md",
+)
+
+
+def find_corpus_files(repo_root: Path) -> List[Path]:
+    """Resolve every glob in CURATED_GLOBS to its actual files."""
+    seen: set[Path] = set()
+    result: List[Path] = []
+    for pattern in CURATED_GLOBS:
+        for match in repo_root.glob(pattern):
+            if match.is_file() and match not in seen:
+                seen.add(match)
+                result.append(match)
+    return sorted(result)
+
+
+# =============================================================================
+# Embedding
+# =============================================================================
+
+
+async def embed_texts(texts: Sequence[str]) -> List[List[float]]:
+    """
+    Get OpenAI embeddings for a batch of strings. 1536-dim each.
+    Caller is responsible for not passing more than the batch limit
+    (OpenAI accepts up to 2048 inputs per call).
+    """
+    if not settings.openai_api_key:
+        raise RagDisabledError("OPENAI_API_KEY is not configured")
+    if not texts:
+        return []
+
+    # Imported lazily so the package isn't required when RAG is off.
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+    response = await client.embeddings.create(
+        model=settings.copilot_rag_embedding_model,
+        input=list(texts),
+    )
+    return [row.embedding for row in response.data]
+
+
+# =============================================================================
+# Indexing (write)
+# =============================================================================
+
+
+def _vector_literal(values: Sequence[float]) -> str:
+    """Render a Python float list as a pgvector literal: '[0.1,0.2,...]'."""
+    return "[" + ",".join(f"{v:.6f}" for v in values) + "]"
+
+
+async def upsert_chunks(
+    db: AsyncSession,
+    chunks: Sequence[DocChunk],
+    embeddings: Sequence[Sequence[float]],
+    *,
+    indexed_at_sql: str = "now()",
+) -> int:
+    """
+    Upsert (source_path, chunk_index) → (content, embedding, metadata).
+    Returns the number of rows touched.
+
+    Run inside the caller's transaction; the caller commits.
+    """
+    if not chunks:
+        return 0
+    if len(chunks) != len(embeddings):
+        raise ValueError(
+            f"chunks/embeddings length mismatch: {len(chunks)} vs {len(embeddings)}"
+        )
+
+    written = 0
+    for chunk, embedding in zip(chunks, embeddings):
+        await db.execute(
+            text(
+                f"""
+                INSERT INTO copilot_doc_chunks
+                    (source_path, chunk_index, content, embedding, metadata, indexed_at)
+                VALUES
+                    (:source_path, :chunk_index, :content, :embedding, :metadata, {indexed_at_sql})
+                ON CONFLICT (source_path, chunk_index)
+                DO UPDATE SET
+                    content    = EXCLUDED.content,
+                    embedding  = EXCLUDED.embedding,
+                    metadata   = EXCLUDED.metadata,
+                    indexed_at = EXCLUDED.indexed_at
+                """
+            ),
+            {
+                "source_path": chunk.source_path,
+                "chunk_index": chunk.chunk_index,
+                "content": chunk.content,
+                "embedding": _vector_literal(embedding),
+                "metadata": chunk.metadata,
+            },
+        )
+        written += 1
+    return written
+
+
+async def delete_stale_chunks(
+    db: AsyncSession,
+    source_path: str,
+    keep_max_index: int,
+) -> int:
+    """
+    Drop chunks whose chunk_index >= `keep_max_index` for a given file
+    — used after re-indexing a file with fewer chunks than before.
+    Returns the number of rows deleted.
+    """
+    result = await db.execute(
+        text(
+            """
+            DELETE FROM copilot_doc_chunks
+             WHERE source_path = :source_path
+               AND chunk_index >= :keep_max_index
+            """
+        ),
+        {"source_path": source_path, "keep_max_index": keep_max_index},
+    )
+    return result.rowcount or 0
+
+
+# =============================================================================
+# Retrieval (read)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class RetrievedChunk:
+    """A chunk returned by similarity search, ordered closest-first."""
+
+    source_path: str
+    chunk_index: int
+    content: str
+    metadata: Dict[str, Any]
+    distance: float
+
+
+async def retrieve_top_k(
+    db: AsyncSession,
+    query: str,
+    *,
+    top_k: Optional[int] = None,
+    min_distance: float = 1.0,
+) -> List[RetrievedChunk]:
+    """
+    Return the `top_k` chunks most similar to `query` by cosine distance.
+    `min_distance` (≤1 by definition for cosine) drops trivially-bad matches.
+    Returns [] if the OpenAI key isn't configured (RAG silently off).
+    """
+    if not settings.openai_api_key:
+        return []
+
+    k = top_k if top_k is not None else settings.copilot_rag_top_k
+    [vector] = await embed_texts([query])
+
+    rows = await db.execute(
+        text(
+            """
+            SELECT source_path, chunk_index, content, metadata,
+                   embedding <=> :vector AS distance
+              FROM copilot_doc_chunks
+             WHERE embedding <=> :vector < :min_distance
+             ORDER BY distance ASC
+             LIMIT :k
+            """
+        ),
+        {
+            "vector": _vector_literal(vector),
+            "min_distance": min_distance,
+            "k": k,
+        },
+    )
+
+    return [
+        RetrievedChunk(
+            source_path=row.source_path,
+            chunk_index=row.chunk_index,
+            content=row.content,
+            metadata=row.metadata or {},
+            distance=float(row.distance),
+        )
+        for row in rows
+    ]
+
+
+# =============================================================================
+# Reindex orchestration (used by app.scripts.index_copilot_docs)
+# =============================================================================
+
+
+async def reindex_file(
+    db: AsyncSession,
+    source_path: str,
+    text_content: str,
+    *,
+    target_chars: Optional[int] = None,
+    embed_batch: int = 64,
+) -> int:
+    """
+    Re-chunk + re-embed + upsert one markdown file. Drops any stale
+    chunks beyond the new chunk count. Returns the number of chunks
+    written (0 if the file embedded as empty).
+    """
+    chunks = chunk_markdown(
+        source_path=source_path,
+        text_content=text_content,
+        target_chars=target_chars or settings.copilot_rag_chunk_chars,
+    )
+    if not chunks:
+        await delete_stale_chunks(db, source_path, keep_max_index=0)
+        return 0
+
+    embeddings: List[List[float]] = []
+    for start in range(0, len(chunks), embed_batch):
+        batch = chunks[start : start + embed_batch]
+        vectors = await embed_texts([c.content for c in batch])
+        embeddings.extend(vectors)
+
+    await upsert_chunks(db, chunks, embeddings)
+    await delete_stale_chunks(db, source_path, keep_max_index=len(chunks))
+    return len(chunks)
+
+
+__all__ = [
+    "CURATED_GLOBS",
+    "DocChunk",
+    "RagDisabledError",
+    "RetrievedChunk",
+    "chunk_markdown",
+    "delete_stale_chunks",
+    "embed_texts",
+    "find_corpus_files",
+    "reindex_file",
+    "retrieve_top_k",
+    "upsert_chunks",
+]

--- a/backend/migrations/versions/20260501_000000_049_copilot_doc_chunks.py
+++ b/backend/migrations/versions/20260501_000000_049_copilot_doc_chunks.py
@@ -1,0 +1,107 @@
+# =============================================================================
+# Stratum AI — Migration: copilot doc chunks (Phase D foundation)
+# =============================================================================
+"""
+Foundation for the Copilot RAG bridge. Enables the pgvector extension
+and creates the `copilot_doc_chunks` table that holds chunked Stratum
+documentation with OpenAI text-embedding-3-small embeddings (1536-dim).
+
+Population is out-of-band via `python -m app.scripts.index_copilot_docs`
+— this migration ships only the schema. The bridge stays off until
+PR 2 wires retrieval into copilot_llm.
+
+Schema:
+  id           BIGSERIAL PRIMARY KEY
+  source_path  TEXT NOT NULL          ← e.g. "docs/04-features/cdp.md"
+  chunk_index  INTEGER NOT NULL       ← 0-based position within the file
+  content      TEXT NOT NULL          ← the chunk text we send to Claude
+  embedding    vector(1536) NOT NULL  ← OpenAI text-embedding-3-small
+  metadata     JSONB NOT NULL DEFAULT '{}'  ← title, heading path, char span
+  indexed_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+
+Indexes:
+  - (source_path, chunk_index) UNIQUE — re-index is upsert-safe
+  - vector index using HNSW with cosine distance — sub-10ms top-k=4
+    on ~1k chunks
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Revision identifiers
+revision = "049_copilot_doc_chunks"
+down_revision = "048_autopilot_outcome_columns"
+branch_labels = None
+depends_on = None
+
+
+def _extension_exists(name: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text("SELECT 1 FROM pg_extension WHERE extname = :name"),
+        {"name": name},
+    )
+    return result.first() is not None
+
+
+def _table_exists(table: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables WHERE table_name = :table"
+        ),
+        {"table": table},
+    )
+    return result.first() is not None
+
+
+def upgrade() -> None:
+    # 1. pgvector. Idempotent on re-run; "IF NOT EXISTS" so we don't choke
+    #    on environments where the operator pre-installed it.
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    if _table_exists("copilot_doc_chunks"):
+        return
+
+    # 2. Table. Use raw DDL because SQLAlchemy core doesn't have a
+    #    first-class vector type without the pgvector dialect plugin,
+    #    and we want this migration to run cleanly even when the Python
+    #    pgvector package isn't installed (e.g. CI without RAG enabled).
+    op.execute(
+        """
+        CREATE TABLE copilot_doc_chunks (
+            id           BIGSERIAL PRIMARY KEY,
+            source_path  TEXT NOT NULL,
+            chunk_index  INTEGER NOT NULL,
+            content      TEXT NOT NULL,
+            embedding    vector(1536) NOT NULL,
+            metadata     JSONB NOT NULL DEFAULT '{}'::jsonb,
+            indexed_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    # 3. Lookup indexes. Unique on (source_path, chunk_index) lets the
+    #    indexer upsert per chunk without duplicates.
+    op.execute(
+        "CREATE UNIQUE INDEX copilot_doc_chunks_source_chunk_uq "
+        "ON copilot_doc_chunks (source_path, chunk_index)"
+    )
+
+    # 4. Vector ANN index. HNSW with cosine distance is fastest for our
+    #    expected scale (~1k chunks). m=16, ef_construction=64 are the
+    #    pgvector defaults; tune later if recall is poor.
+    op.execute(
+        "CREATE INDEX copilot_doc_chunks_embedding_hnsw "
+        "ON copilot_doc_chunks USING hnsw (embedding vector_cosine_ops)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS copilot_doc_chunks_embedding_hnsw")
+    op.execute("DROP INDEX IF EXISTS copilot_doc_chunks_source_chunk_uq")
+    op.execute("DROP TABLE IF EXISTS copilot_doc_chunks")
+    # Don't drop the extension — other tables may use it later. Leaving
+    # the extension in place is the safe default for an additive
+    # downgrade.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -55,6 +55,8 @@ google-auth==2.50.0
 
 # LLM Integrations (Copilot)
 anthropic==0.45.2
+openai==1.54.0
+pgvector==0.3.6
 
 # Web Scraping (Module D)
 beautifulsoup4==4.14.3

--- a/backend/tests/unit/test_doc_index.py
+++ b/backend/tests/unit/test_doc_index.py
@@ -1,0 +1,255 @@
+# =============================================================================
+# Stratum AI — doc_index tests (Copilot RAG foundation)
+# =============================================================================
+"""
+Pure-Python tests for the chunker + helpers. The OpenAI and pgvector
+integrations are mocked — these tests run without OPENAI_API_KEY and
+without a Postgres connection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.agents.doc_index import (
+    CURATED_GLOBS,
+    DocChunk,
+    RagDisabledError,
+    chunk_markdown,
+    embed_texts,
+    find_corpus_files,
+    _heading_path_for_offset,
+    _vector_literal,
+    _walk_headings,
+)
+
+
+# =============================================================================
+# Chunking
+# =============================================================================
+
+
+class TestChunkMarkdown:
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert chunk_markdown("docs/x.md", "") == []
+        assert chunk_markdown("docs/x.md", "   \n\n   ") == []
+
+    def test_single_short_paragraph_is_one_chunk(self) -> None:
+        chunks = chunk_markdown(
+            "docs/x.md",
+            "# Title\n\nHello world. This is a short paragraph.",
+            target_chars=500,
+        )
+        assert len(chunks) == 1
+        assert chunks[0].source_path == "docs/x.md"
+        assert chunks[0].chunk_index == 0
+        assert "Hello world" in chunks[0].content
+
+    def test_long_doc_splits_at_paragraph_boundaries(self) -> None:
+        para = "Lorem ipsum dolor sit amet. " * 30  # ~810 chars
+        text = f"# Title\n\n{para}\n\n{para}\n\n{para}"
+        chunks = chunk_markdown("docs/x.md", text, target_chars=900)
+        # 3 paragraphs of ~810 chars each, target 900 → can't pair them.
+        assert len(chunks) >= 3
+        # No chunk crosses the target by more than one paragraph.
+        for c in chunks:
+            assert len(c.content) < 1800
+
+    def test_chunk_index_is_zero_based_and_sequential(self) -> None:
+        text = "\n\n".join(f"Paragraph number {i}." for i in range(20))
+        chunks = chunk_markdown("docs/x.md", text, target_chars=80)
+        indices = [c.chunk_index for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+    def test_metadata_records_heading_path(self) -> None:
+        text = (
+            "# Top Level\n\n"
+            "Intro paragraph.\n\n"
+            "## Subsection A\n\n"
+            "Subsection paragraph.\n\n"
+            "## Subsection B\n\n"
+            "Another paragraph here that is intentionally longer to land in its own chunk because target is small.\n"
+        )
+        chunks = chunk_markdown("docs/x.md", text, target_chars=80)
+        # Find the chunk that starts inside Subsection B.
+        b_chunks = [
+            c for c in chunks if "Another paragraph here" in c.content
+        ]
+        assert b_chunks, "expected to find a chunk for Subsection B"
+        assert b_chunks[0].metadata["title"] == "Subsection B"
+        assert b_chunks[0].metadata["heading_path"][-1] == "Subsection B"
+
+    def test_code_fences_are_not_split(self) -> None:
+        text = (
+            "# Title\n\n"
+            "Some intro.\n\n"
+            "```python\n"
+            "def hello():\n"
+            "    print('a' * 200)\n"
+            "    print('b' * 200)\n"
+            "    print('c' * 200)\n"
+            "```\n\n"
+            "Some outro.\n"
+        )
+        chunks = chunk_markdown("docs/x.md", text, target_chars=200)
+        # The code fence is a single paragraph; whichever chunk it lands in
+        # contains the whole fence intact.
+        fence_chunks = [c for c in chunks if "```python" in c.content]
+        assert len(fence_chunks) == 1
+        assert "```python" in fence_chunks[0].content
+        assert "```" in fence_chunks[0].content[fence_chunks[0].content.rindex("```python") + 1 :]
+
+    def test_chunk_content_is_stripped(self) -> None:
+        chunks = chunk_markdown("docs/x.md", "\n\n  Hello.  \n\n  World.  \n\n", target_chars=500)
+        assert len(chunks) == 1
+        assert chunks[0].content.strip() == chunks[0].content
+
+    def test_target_chars_packs_multiple_paragraphs(self) -> None:
+        # Each paragraph is 40 chars + 2 chars for the "\n\n" join.
+        # Target 100 → two paragraphs (40+2+40=82) fit; a third (122) does not.
+        # Expect ~5 chunks for 10 paragraphs.
+        text = "\n\n".join(["x" * 40] * 10)
+        chunks = chunk_markdown("docs/x.md", text, target_chars=100)
+        assert 4 <= len(chunks) <= 6  # tolerance for boundary handling
+
+
+# =============================================================================
+# Heading walker
+# =============================================================================
+
+
+class TestWalkHeadings:
+    def test_picks_up_all_levels(self) -> None:
+        text = "# A\n\n## B\n\n### C\n\nbody\n"
+        headings = _walk_headings(text)
+        levels = [h["level"] for h in headings]
+        titles = [h["title"] for h in headings]
+        assert levels == [1, 2, 3]
+        assert titles == ["A", "B", "C"]
+
+    def test_offset_path_pops_siblings(self) -> None:
+        text = "# A\n\n## B\n\n## C\n\nbody"
+        headings = _walk_headings(text)
+        offset = text.index("body")
+        path = _heading_path_for_offset(headings, offset)
+        # B is a sibling of C; only the most recent ## stays.
+        assert path == ["A", "C"]
+
+    def test_offset_before_first_heading_is_empty(self) -> None:
+        text = "preface\n\n# A"
+        headings = _walk_headings(text)
+        assert _heading_path_for_offset(headings, 0) == []
+
+
+# =============================================================================
+# Vector literal
+# =============================================================================
+
+
+class TestVectorLiteral:
+    def test_round_trip_format(self) -> None:
+        out = _vector_literal([0.1, 0.2, 0.3])
+        assert out.startswith("[") and out.endswith("]")
+        # 6 decimal places per element, comma separated, no spaces.
+        assert out == "[0.100000,0.200000,0.300000]"
+
+    def test_handles_negative_and_large_values(self) -> None:
+        out = _vector_literal([-1.234567, 1000.5])
+        assert out == "[-1.234567,1000.500000]"
+
+    def test_empty_vector(self) -> None:
+        assert _vector_literal([]) == "[]"
+
+
+# =============================================================================
+# Embedding gate
+# =============================================================================
+
+
+class TestEmbedTexts:
+    @pytest.mark.asyncio
+    async def test_raises_when_api_key_missing(self) -> None:
+        with patch("app.services.agents.doc_index.settings") as mock_settings:
+            mock_settings.openai_api_key = None
+            with pytest.raises(RagDisabledError):
+                await embed_texts(["hello"])
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_for_empty_input(self) -> None:
+        with patch("app.services.agents.doc_index.settings") as mock_settings:
+            mock_settings.openai_api_key = "sk-test"
+            assert await embed_texts([]) == []
+
+    @pytest.mark.asyncio
+    async def test_calls_openai_with_configured_model(self) -> None:
+        fake_response = type(
+            "X", (), {"data": [type("R", (), {"embedding": [0.1] * 1536})()]}
+        )()
+        fake_client = type(
+            "C",
+            (),
+            {
+                "embeddings": type(
+                    "E",
+                    (),
+                    {"create": AsyncMock(return_value=fake_response)},
+                )()
+            },
+        )()
+        with (
+            patch("app.services.agents.doc_index.settings") as mock_settings,
+            patch("openai.AsyncOpenAI", return_value=fake_client) as mock_factory,
+        ):
+            mock_settings.openai_api_key = "sk-test"
+            mock_settings.copilot_rag_embedding_model = "text-embedding-3-small"
+            result = await embed_texts(["hello"])
+            assert mock_factory.called
+            assert len(result) == 1
+            assert len(result[0]) == 1536
+
+
+# =============================================================================
+# Corpus discovery
+# =============================================================================
+
+
+class TestFindCorpusFiles:
+    def test_returns_only_existing_md_files(self, tmp_path: Path) -> None:
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "00-overview").mkdir()
+        (tmp_path / "docs" / "00-overview" / "vision.md").write_text("# Vision")
+        (tmp_path / "docs" / "00-overview" / "ignore.txt").write_text("nope")
+        (tmp_path / "docs" / "04-features").mkdir()
+        (tmp_path / "docs" / "04-features" / "cdp.md").write_text("# CDP")
+
+        files = find_corpus_files(tmp_path)
+        rel = sorted(str(f.relative_to(tmp_path)) for f in files)
+        assert "docs/00-overview/vision.md" in rel
+        assert "docs/04-features/cdp.md" in rel
+        assert all(".md" in f for f in rel)
+
+    def test_curated_globs_are_documented(self) -> None:
+        # Sanity: the constant the indexer falls back to is non-empty
+        # and points at locations that exist in this repo (smoke).
+        assert len(CURATED_GLOBS) >= 5
+        # Globs all start with docs/ so they're confined to the corpus.
+        assert all(g.startswith("docs/") for g in CURATED_GLOBS)
+
+
+# =============================================================================
+# DocChunk dataclass
+# =============================================================================
+
+
+class TestDocChunk:
+    def test_default_metadata_is_dict(self) -> None:
+        c = DocChunk(source_path="x.md", chunk_index=0, content="hi")
+        assert c.metadata == {}
+
+    def test_is_frozen(self) -> None:
+        c = DocChunk(source_path="x.md", chunk_index=0, content="hi")
+        with pytest.raises(Exception):
+            c.content = "no"  # type: ignore[misc]

--- a/docs/06-deploy/copilot-rag-indexing.md
+++ b/docs/06-deploy/copilot-rag-indexing.md
@@ -1,0 +1,150 @@
+# Activation Checklist — Copilot RAG (Phase D, foundation)
+
+The Copilot RAG bridge is being shipped in three pieces. This doc
+covers **Phase D Part 1 — indexing infrastructure** (PR #270 follow-up).
+The bridge stays off until PR 2 wires retrieval into `copilot_llm`.
+
+## What this PR ships
+
+```
+backend/migrations/versions/049_copilot_doc_chunks.py     pgvector + table
+backend/app/models/copilot_doc.py                         CopilotDocChunk model
+backend/app/services/agents/doc_index.py                  chunking + embed + retrieve
+backend/app/scripts/index_copilot_docs.py                 CLI re-indexer
+backend/requirements.txt                                  openai==1.54.0, pgvector==0.3.6
+backend/app/core/config.py                                copilot_rag_* settings
+```
+
+The bridge calls `retrieve_top_k()` only when `COPILOT_RAG_ENABLED=true`.
+Until PR 2 lands, that flag has no consumer — toggling it on does
+nothing except make the indexer require an OpenAI key.
+
+## Step 1 — Run the migration
+
+```
+make migrate
+```
+
+Adds the `vector` extension and the `copilot_doc_chunks` table. If
+your Postgres image doesn't include pgvector (vanilla `postgres:16`
+does _not_), pull `pgvector/pgvector:pg16` first. The migration is
+no-op on re-run.
+
+## Step 2 — Get an OpenAI API key
+
+1. https://platform.openai.com → API keys → Create
+2. Treat like Stripe — store in your password manager, never paste
+   in chat.
+3. Set a usage cap (Settings → Limits) — `text-embedding-3-small`
+   is `$0.02 / 1M tokens`. Re-indexing the curated corpus once costs
+   well under a penny.
+
+## Step 3 — Set Railway env vars
+
+| Variable                      | Value                         |
+| ----------------------------- | ----------------------------- |
+| `OPENAI_API_KEY`              | the `sk-…` key from Step 2    |
+| `COPILOT_RAG_ENABLED`         | `false` (leave off until PR2) |
+| `COPILOT_RAG_EMBEDDING_MODEL` | `text-embedding-3-small`      |
+| `COPILOT_RAG_TOP_K`           | `4` (default)                 |
+| `COPILOT_RAG_CHUNK_CHARS`     | `1200` (default)              |
+
+## Step 4 — Index the curated corpus
+
+From inside the backend container or Railway shell:
+
+```
+python -m app.scripts.index_copilot_docs
+```
+
+Output looks like:
+
+```
+Target: 32 markdown file(s).
+  docs/00-overview/glossary.md  →  9 chunks
+  docs/00-overview/vision.md  →  4 chunks
+  ...
+Indexed 187 chunks across 32 files.
+```
+
+The CLI is idempotent — re-running just refreshes existing rows. Run
+it after every meaningful docs edit; you can hook it into CI later.
+
+To verify before committing OpenAI spend:
+
+```
+python -m app.scripts.index_copilot_docs --dry-run
+```
+
+## Step 5 — Verify in Postgres
+
+```
+SELECT count(*) FROM copilot_doc_chunks;
+SELECT source_path, count(*) FROM copilot_doc_chunks GROUP BY source_path ORDER BY 2 DESC LIMIT 10;
+```
+
+Expected: ~150–200 chunks across ~30 files for the curated corpus.
+
+## Step 6 — Smoke a retrieval (manual)
+
+The bridge isn't wired yet, but you can test retrieval directly:
+
+```python
+import asyncio
+from app.db.session import async_session_factory
+from app.services.agents.doc_index import retrieve_top_k
+
+async def main():
+    async with async_session_factory() as db:
+        chunks = await retrieve_top_k(db, "What is signal health?", top_k=3)
+        for c in chunks:
+            print(f"{c.source_path}#{c.chunk_index}  d={c.distance:.3f}")
+            print(c.content[:200], "...\n")
+
+asyncio.run(main())
+```
+
+Expected: top hit is the trust-engine or glossary doc.
+
+## Rollback
+
+The migration's `downgrade()` drops the table and indexes. The
+extension is left in place for future tables.
+
+```
+alembic downgrade 048
+```
+
+## Cost monitoring
+
+Re-indexing the curated corpus is a one-shot cost (~$0.001). Once
+PR 2 wires retrieval, every Copilot question costs 1 embedding call
+(~$0.00002) before the Claude completion — negligible. Track via
+the structlog event `copilot_rag_retrieved` (added in PR 2).
+
+## Adjusting the corpus
+
+Edit `CURATED_GLOBS` in `backend/app/services/agents/doc_index.py`.
+Re-run the indexer. Stale chunks for files that no longer match are
+automatically dropped per-file by `reindex_file()`'s
+`delete_stale_chunks()`, but files removed from the glob list aren't
+auto-cleaned — drop them manually:
+
+```
+DELETE FROM copilot_doc_chunks WHERE source_path = 'docs/old-thing.md';
+```
+
+## Out of scope (deferred)
+
+- Wiring retrieval into `copilot_llm.generate_llm_message` — PR 2.
+- Streaming responses + frontend EventSource — PR 3.
+- Auto-reindex on docs/ edits — would need a CI job or git hook.
+- Per-tenant docs (e.g. tenant-uploaded help articles) — current
+  scope is platform docs only.
+
+## Owner
+
+Same as Phase D Part 0 (the original LLM bridge): operator setting
+the env vars must have **superadmin** role on the platform. The
+OpenAI key is workspace-scoped to your OpenAI account, not bound
+to a Stratum user.


### PR DESCRIPTION
First of three PRs for the Copilot RAG bridge. This PR ships the **indexing pipeline only** — bridge wiring lands in PR2, streaming in PR3. The bridge stays off until COPILOT_RAG_ENABLED flips.

Architecture decisions (locked):
- Vector store: pgvector (extension + HNSW cosine index).
- Embeddings: OpenAI text-embedding-3-small (1536-dim).
- Curated corpus: docs/00-overview, 04-features, 07-user-guide, trust-engine, system-architecture, figma-theme. ~30 files, ~150-200 chunks expected. Excludes dev/ops docs that would pollute operator queries.

Adds:

  backend/migrations/versions/049_copilot_doc_chunks.py Enables pgvector, creates copilot_doc_chunks table with HNSW index. Idempotent on re-run; downgrade drops table only.

  backend/app/models/copilot_doc.py SQLAlchemy mapping. The vector column is touched only via raw SQL helpers in doc_index — no ORM dependency on pgvector-python.

  backend/app/services/agents/doc_index.py
    - chunk_markdown(): paragraph-boundary chunker, code-fence-aware, heading-path metadata.
    - embed_texts(): OpenAI batch embedding with RagDisabledError when OPENAI_API_KEY missing.
    - upsert_chunks() / delete_stale_chunks(): idempotent reindex via raw SQL with vector literal formatting.
    - retrieve_top_k(): cosine-distance ANN search returning RetrievedChunk (content + heading metadata + distance).
    - reindex_file(): chunk → embed-batched → upsert orchestration.

  backend/app/scripts/index_copilot_docs.py
    CLI: `python -m app.scripts.index_copilot_docs [--dry-run] [paths…]`.
    Curated corpus is the default target; specific paths override.

  backend/app/core/config.py
    Five new settings: copilot_rag_enabled, openai_api_key,
    copilot_rag_embedding_model, copilot_rag_top_k, copilot_rag_chunk_chars.

  backend/requirements.txt
    + openai==1.54.0  + pgvector==0.3.6

  backend/tests/unit/test_doc_index.py
    21 tests: chunking edge cases (empty, code fences, heading paths, target sizing, frozen dataclass), heading walker (sibling pop, pre-heading offset), vector literal formatting, embed_texts gate (missing key raises, empty input, model passthrough), corpus discovery. All mock OpenAI; no DB required.

  docs/06-deploy/copilot-rag-indexing.md
    Operator runbook: migration, OpenAI key, env vars, indexing CLI, Postgres verification, rollback.

Suite: 21/21 backend tests pass; frontend untouched (117 sample green, 992 full last verified). tsc clean.

Next: PR2 wires retrieve_top_k into copilot_llm.generate_llm_message and adds doc citations to the response. PR3 ships SSE streaming.

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
