### PR TITLE
feat(copilot): SSE streaming + token-by-token rendering (Phase D PR3)

### DIFF
--- a/backend/app/api/v1/endpoints/copilot.py
+++ b/backend/app/api/v1/endpoints/copilot.py
@@ -10,10 +10,11 @@ contextual recommendations.
 """
 
 from datetime import UTC, datetime
-from typing import Optional
+from typing import Optional, Tuple
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, select, text
 from sqlalchemy.exc import SQLAlchemyError
@@ -29,6 +30,7 @@ from app.services.agents.copilot_agent import (
     process_message,
 )
 from app.services.agents.copilot_llm import generate_llm_message
+from app.services.agents.copilot_llm_stream import stream_llm_message
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/copilot", tags=["copilot"])
@@ -64,32 +66,21 @@ class CopilotMessageResponse(BaseModel):
 
 
 # =============================================================================
-# Endpoints
+# Context gathering (shared between /chat and /chat/stream)
 # =============================================================================
 
-@router.post("/chat", response_model=APIResponse[CopilotMessageResponse])
-async def copilot_chat(
-    request: CopilotMessageRequest,
-    user: CurrentUserDep,
-    db: AsyncSession = Depends(get_async_session),
-):
+
+async def _gather_context(
+    *,
+    db: AsyncSession,
+    tenant_id: int,
+) -> Tuple[Optional[dict], dict, Optional[dict]]:
     """
-    Send a message to the AI Copilot and receive a data-aware response.
-
-    The copilot analyzes the user's query, fetches relevant dashboard data,
-    and generates a contextual response with suggestions and data cards.
+    Fetch the live tenant signals the copilot needs: campaign rollup,
+    signal-health snapshot, lightweight anomaly summary. Each block
+    fails open — partial context is better than no response.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
-    user_name = getattr(user, "full_name", None) or getattr(user, "email", "User")
-    if user_name and "@" in user_name:
-        user_name = user_name.split("@")[0].title()
-
-    session_id = request.session_id or str(uuid4())
-
-    # ── Gather context data for the copilot ──────────────────────
-
-    # 1. Campaign metrics
-    metrics = None
+    metrics: Optional[dict] = None
     try:
         campaign_result = await db.execute(
             select(
@@ -108,13 +99,11 @@ async def copilot_chat(
             )
         )
         row = campaign_result.one_or_none()
-
         if row and row.total > 0:
             spend = float(row.spend_cents or 0) / 100
             revenue = float(row.revenue_cents or 0) / 100
             conversions = int(row.conversions or 0)
             roas = revenue / spend if spend > 0 else 0.0
-
             metrics = {
                 "spend": spend,
                 "revenue": revenue,
@@ -122,16 +111,14 @@ async def copilot_chat(
                 "conversions": conversions,
                 "active_campaigns": row.active,
                 "total_campaigns": row.total,
-                "spend_change_pct": None,  # Would need historical comparison
+                "spend_change_pct": None,
                 "revenue_change_pct": None,
             }
     except (SQLAlchemyError, ValueError, TypeError) as e:
         logger.debug("copilot_metrics_fetch_error", error=str(e))
 
-    # 2. Signal health data
-    health_data = None
+    health_data: dict
     try:
-        # Check EMQ degradation alerts
         emq_result = await db.execute(
             text(
                 "SELECT COUNT(*) as degraded_count "
@@ -144,7 +131,6 @@ async def copilot_chat(
         )
         emq_row = emq_result.mappings().first()
         emq_degraded = emq_row["degraded_count"] if emq_row else 0
-
         if emq_degraded == 0:
             emq_score = 0.95
             overall = 85
@@ -157,7 +143,6 @@ async def copilot_chat(
             emq_score = 0.50
             overall = 40
             health_status = "critical"
-
         health_data = {
             "overall_score": overall,
             "status": health_status,
@@ -167,7 +152,6 @@ async def copilot_chat(
         }
     except (SQLAlchemyError, TypeError, KeyError) as e:
         logger.debug("copilot_health_fetch_error", error=str(e))
-        # Return unknown status rather than fabricated healthy scores
         health_data = {
             "overall_score": None,
             "status": "unknown",
@@ -176,11 +160,8 @@ async def copilot_chat(
             "issues": ["Unable to fetch signal health data"],
         }
 
-    # 3. Anomaly data (lightweight — just counts)
-    anomaly_data = None
+    anomaly_data: Optional[dict] = None
     if metrics and metrics.get("spend", 0) > 0:
-        # We provide a lightweight anomaly summary
-        # (full anomaly detection is expensive, done by the dedicated endpoint)
         anomaly_data = {
             "total_anomalies": 0,
             "critical_count": 0,
@@ -191,6 +172,42 @@ async def copilot_chat(
             "correlations": [],
         }
 
+    return metrics, health_data, anomaly_data
+
+
+def _resolve_user_name(user) -> Tuple[Optional[str], Optional[str]]:
+    """Return (display_name, first_name) — the bridge wants the first name only."""
+    user_name = getattr(user, "full_name", None) or getattr(user, "email", "User")
+    if user_name and "@" in user_name:
+        user_name = user_name.split("@")[0].title()
+    first_name = user_name.split()[0] if user_name else None
+    return user_name, first_name
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+@router.post("/chat", response_model=APIResponse[CopilotMessageResponse])
+async def copilot_chat(
+    request: CopilotMessageRequest,
+    user: CurrentUserDep,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Send a message to the AI Copilot and receive a data-aware response.
+
+    The copilot analyzes the user's query, fetches relevant dashboard data,
+    and generates a contextual response with suggestions and data cards.
+    """
+    tenant_id = getattr(user, "tenant_id", None) or 1
+    _, first_name = _resolve_user_name(user)
+
+    session_id = request.session_id or str(uuid4())
+
+    # ── Gather context data for the copilot ──────────────────────
+    metrics, health_data, anomaly_data = await _gather_context(db=db, tenant_id=tenant_id)
+
     # ── Process message through copilot agent ────────────────────
     # The keyword classifier always runs first — it produces the intent,
     # the suggestion chips, and the structured data cards that the
@@ -198,8 +215,6 @@ async def copilot_chat(
     # enabled we additionally swap in a Claude-generated response text
     # using the same live context. On any LLM failure the template
     # message stays in place — the user never sees a degraded experience.
-
-    first_name = user_name.split()[0] if user_name else None
 
     response = process_message(
         message=request.message,
@@ -251,4 +266,77 @@ async def copilot_chat(
             timestamp=datetime.now(UTC).isoformat(),
         ),
         message="Copilot response generated",
+    )
+
+
+# =============================================================================
+# Streaming endpoint
+# =============================================================================
+
+
+@router.post("/chat/stream")
+async def copilot_chat_stream(
+    request: CopilotMessageRequest,
+    user: CurrentUserDep,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Stream the AI Copilot response as Server-Sent Events.
+
+    Wire format (per `app.services.agents.copilot_llm_stream`):
+
+        event: token   data: <text fragment>     ← multiple, in order
+        event: meta    data: {citations, intent, suggestions, data_cards,
+                              fallback_message?}  ← exactly one
+        event: error   data: <short reason>      ← optional, before meta
+        data: [DONE]                              ← always last
+
+    The frontend appends `token` events to a growing assistant bubble,
+    swaps in `fallback_message` if it's present (LLM failed before any
+    tokens), and renders citations + suggestions + data_cards from the
+    `meta` payload once the stream completes.
+    """
+    tenant_id = getattr(user, "tenant_id", None) or 1
+    _, first_name = _resolve_user_name(user)
+    session_id = request.session_id or str(uuid4())
+
+    metrics, health_data, anomaly_data = await _gather_context(db=db, tenant_id=tenant_id)
+    base_response = process_message(
+        message=request.message,
+        user_name=first_name,
+        metrics=metrics,
+        health_data=health_data,
+        anomaly_data=anomaly_data,
+    )
+
+    async def _event_stream():
+        # Emit a session_id event up front so the frontend can pin
+        # this stream to a conversation without waiting for meta.
+        yield (
+            f"event: session\ndata: {session_id}\n\n"
+        )
+        async for chunk in stream_llm_message(
+            message=request.message,
+            user_name=first_name,
+            metrics=metrics,
+            health_data=health_data,
+            anomaly_data=anomaly_data,
+            intent=base_response.intent,
+            suggestions=base_response.suggestions,
+            data_cards=base_response.data_cards,
+            fallback_message=base_response.message,
+            db=db,
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        _event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            # Disable buffering on Cloudflare / nginx so tokens render
+            # in real time rather than getting batched at proxy edges.
+            "X-Accel-Buffering": "no",
+        },
     )

--- a/backend/app/services/agents/copilot_llm_stream.py
+++ b/backend/app/services/agents/copilot_llm_stream.py
@@ -1,0 +1,273 @@
+# =============================================================================
+# Stratum AI - Copilot LLM Streaming Bridge
+# =============================================================================
+"""
+Streaming variant of the Copilot LLM bridge.
+
+Yields SSE-shaped events for the FastAPI /copilot/chat/stream endpoint
+to relay to the browser. The contract is intentionally narrow so the
+frontend SSE parser stays simple:
+
+    event: token   data: "<text fragment>"   ← multiple, in order
+    event: meta    data: {                    ← exactly one, before [DONE]
+        "citations": [...],
+        "intent": "...",
+        "suggestions": [...],
+        "data_cards": [...],
+        "fallback_message": "...",            ← only present if streaming failed
+    }
+    event: error   data: "<short message>"    ← optional; followed by meta
+    data: [DONE]                              ← always last
+
+Token events are plain text (not JSON) because that's the natural
+shape Anthropic streams and the frontend just needs to append. The
+`meta` event is a single JSON object so the dashboard can render
+citations, suggestions, and data cards once the stream completes.
+
+Failure semantics are preserved: any failure path emits a meta event
+with `fallback_message` populated from the keyword classifier so the
+dashboard can replace the partial stream with the deterministic
+template message rather than show a half-written response.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.services.agents.copilot_llm import (
+    Citation,
+    SYSTEM_PROMPT,
+    _build_user_prompt,
+    _retrieve_docs,
+)
+
+logger = get_logger(__name__)
+
+
+# =============================================================================
+# SSE event helpers
+# =============================================================================
+
+
+def _format_sse(event: str, data: str) -> str:
+    """Frame a single SSE event. data is escaped per the SSE spec."""
+    payload = data.replace("\r\n", "\n")
+    lines = [f"event: {event}"]
+    for line in payload.split("\n"):
+        lines.append(f"data: {line}")
+    lines.append("")  # trailing blank line terminates the event
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _format_sse_done() -> str:
+    """The terminal '[DONE]' marker — separate event since it has no `event:` field."""
+    return "data: [DONE]\n\n"
+
+
+def _meta_payload(
+    *,
+    citations: List[Citation],
+    intent: str,
+    suggestions: List[str],
+    data_cards: List[Dict[str, Any]],
+    fallback_message: Optional[str] = None,
+) -> str:
+    """Build the JSON body of the `meta` event."""
+    body: Dict[str, Any] = {
+        "intent": intent,
+        "suggestions": suggestions,
+        "data_cards": data_cards,
+        "citations": [
+            {
+                "source_path": c.source_path,
+                "title": c.title,
+                "distance": c.distance,
+            }
+            for c in citations
+        ],
+    }
+    if fallback_message is not None:
+        body["fallback_message"] = fallback_message
+    return json.dumps(body, default=str)
+
+
+# =============================================================================
+# Streaming generator
+# =============================================================================
+
+
+async def stream_llm_message(
+    *,
+    message: str,
+    user_name: Optional[str],
+    metrics: Optional[Dict[str, Any]],
+    health_data: Optional[Dict[str, Any]],
+    anomaly_data: Optional[Dict[str, Any]],
+    intent: str,
+    suggestions: List[str],
+    data_cards: List[Dict[str, Any]],
+    fallback_message: str,
+    db: Optional[AsyncSession] = None,
+) -> AsyncIterator[str]:
+    """
+    Async generator that yields SSE-formatted strings.
+
+    `fallback_message` is the keyword-classifier template — emitted in
+    the meta event whenever the LLM path fails so the frontend can
+    swap the partial stream for the deterministic message.
+    """
+    # ── Off-paths emit fallback meta + done immediately ───────────────
+    if not settings.copilot_llm_enabled or not settings.anthropic_api_key:
+        yield _format_sse(
+            "meta",
+            _meta_payload(
+                citations=[],
+                intent=intent,
+                suggestions=suggestions,
+                data_cards=data_cards,
+                fallback_message=fallback_message,
+            ),
+        )
+        yield _format_sse_done()
+        return
+
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError:
+        logger.warning("copilot_llm_anthropic_sdk_missing")
+        yield _format_sse(
+            "meta",
+            _meta_payload(
+                citations=[],
+                intent=intent,
+                suggestions=suggestions,
+                data_cards=data_cards,
+                fallback_message=fallback_message,
+            ),
+        )
+        yield _format_sse_done()
+        return
+
+    docs, citations = await _retrieve_docs(db, message)
+
+    client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+    user_prompt = _build_user_prompt(
+        message=message,
+        user_name=user_name,
+        metrics=metrics,
+        health_data=health_data,
+        anomaly_data=anomaly_data,
+        intent=intent,
+        docs=docs,
+    )
+
+    text_chars = 0
+    final_stop_reason: Optional[str] = None
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    streamed_any_token = False
+
+    try:
+        async with asyncio.timeout(settings.copilot_llm_timeout_seconds):
+            async with client.messages.stream(
+                model=settings.copilot_llm_model,
+                max_tokens=settings.copilot_llm_max_tokens,
+                system=SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+            ) as stream:
+                async for text_delta in stream.text_stream:
+                    if not text_delta:
+                        continue
+                    streamed_any_token = True
+                    text_chars += len(text_delta)
+                    yield _format_sse("token", text_delta)
+                # Final metadata when the stream completes cleanly.
+                final_message = await stream.get_final_message()
+                final_stop_reason = getattr(final_message, "stop_reason", None)
+                usage = getattr(final_message, "usage", None)
+                if usage is not None:
+                    input_tokens = getattr(usage, "input_tokens", None)
+                    output_tokens = getattr(usage, "output_tokens", None)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "copilot_llm_stream_timeout",
+            timeout=settings.copilot_llm_timeout_seconds,
+            model=settings.copilot_llm_model,
+            streamed_any_token=streamed_any_token,
+        )
+        yield _format_sse("error", "timeout")
+        yield _format_sse(
+            "meta",
+            _meta_payload(
+                citations=citations,
+                intent=intent,
+                suggestions=suggestions,
+                data_cards=data_cards,
+                fallback_message=fallback_message if not streamed_any_token else None,
+            ),
+        )
+        yield _format_sse_done()
+        return
+    except Exception as exc:  # noqa: BLE001 — fail open
+        logger.warning(
+            "copilot_llm_stream_error",
+            error_type=type(exc).__name__,
+            error=str(exc)[:200],
+            model=settings.copilot_llm_model,
+            streamed_any_token=streamed_any_token,
+        )
+        yield _format_sse("error", "stream_error")
+        yield _format_sse(
+            "meta",
+            _meta_payload(
+                citations=citations,
+                intent=intent,
+                suggestions=suggestions,
+                data_cards=data_cards,
+                fallback_message=fallback_message if not streamed_any_token else None,
+            ),
+        )
+        yield _format_sse_done()
+        return
+
+    # ── Success: emit meta + done ─────────────────────────────────────
+    yield _format_sse(
+        "meta",
+        _meta_payload(
+            citations=citations,
+            intent=intent,
+            suggestions=suggestions,
+            data_cards=data_cards,
+            # fallback only if the model produced nothing at all
+            fallback_message=fallback_message if not streamed_any_token else None,
+        ),
+    )
+    yield _format_sse_done()
+
+    logger.info(
+        "copilot_llm_stream_complete",
+        model=settings.copilot_llm_model,
+        intent=intent,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        stop_reason=final_stop_reason,
+        message_chars=text_chars,
+        citation_count=len(citations),
+        rag_enabled=settings.copilot_rag_enabled and len(docs) > 0,
+    )
+
+
+__all__ = [
+    "_format_sse",
+    "_format_sse_done",
+    "_meta_payload",
+    "stream_llm_message",
+]

--- a/backend/tests/unit/test_copilot_llm_stream.py
+++ b/backend/tests/unit/test_copilot_llm_stream.py
@@ -1,0 +1,381 @@
+# =============================================================================
+# Stratum AI — copilot_llm_stream tests (Phase D PR3)
+# =============================================================================
+"""
+Verifies the SSE streaming bridge wires Anthropic streaming + RAG
+retrieval together correctly. Anthropic streaming, OpenAI, and pgvector
+are all mocked — runs without network, DB, or live LLM keys.
+
+Covered behavior:
+
+- Off-paths (LLM disabled / no key / SDK missing) emit only meta+done
+  with `fallback_message` set, no token events.
+- Happy path streams tokens in order, then meta with citations,
+  then [DONE].
+- `fallback_message` is omitted from meta when at least one token
+  was streamed (success); included when zero tokens streamed (failure).
+- Timeout emits `error: timeout` then meta then [DONE].
+- Anthropic SDK exceptions emit `error: stream_error` then meta + done.
+- SSE wire format: `event: <name>` and `data: <line>` framing,
+  trailing blank line per event, terminal `[DONE]`.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.agents.copilot_llm import Citation
+from app.services.agents.copilot_llm_stream import (
+    _format_sse,
+    _format_sse_done,
+    _meta_payload,
+    stream_llm_message,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _patch_settings(**overrides: Any):
+    base = {
+        "copilot_llm_enabled": True,
+        "anthropic_api_key": "sk-ant-test",
+        "copilot_llm_model": "claude-haiku-4-5",
+        "copilot_llm_max_tokens": 600,
+        "copilot_llm_timeout_seconds": 8.0,
+        "copilot_rag_enabled": False,
+        "openai_api_key": None,
+    }
+    base.update(overrides)
+    return patch.multiple(
+        "app.services.agents.copilot_llm_stream.settings",
+        **base,
+    )
+
+
+class _FakeStream:
+    """Mimics the Anthropic streaming context manager."""
+
+    def __init__(self, tokens: List[str], stop_reason: str = "end_turn",
+                 input_tokens: int = 100, output_tokens: int = 50,
+                 raise_during: bool = False) -> None:
+        self.tokens = tokens
+        self.stop_reason = stop_reason
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.raise_during = raise_during
+
+    async def __aenter__(self) -> "_FakeStream":
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    @property
+    def text_stream(self) -> AsyncIterator[str]:
+        return self._iter()
+
+    async def _iter(self) -> AsyncIterator[str]:
+        for tok in self.tokens:
+            if self.raise_during:
+                raise RuntimeError("network blew up")
+            yield tok
+
+    async def get_final_message(self) -> Any:
+        msg = MagicMock()
+        msg.stop_reason = self.stop_reason
+        msg.usage = MagicMock(
+            input_tokens=self.input_tokens,
+            output_tokens=self.output_tokens,
+        )
+        return msg
+
+
+def _fake_anthropic_client(stream: _FakeStream) -> MagicMock:
+    client = MagicMock()
+    # client.messages.stream(...) must return an async-context-manager.
+    client.messages.stream = MagicMock(return_value=stream)
+    return client
+
+
+async def _collect(gen) -> List[str]:
+    """Drain an async generator into a list."""
+    return [x async for x in gen]
+
+
+# =============================================================================
+# SSE format helpers
+# =============================================================================
+
+
+class TestSSEFormatting:
+    def test_format_sse_single_line(self) -> None:
+        out = _format_sse("token", "hello")
+        # Per SSE spec, an event terminates with a blank line (\n\n).
+        assert out == "event: token\ndata: hello\n\n"
+
+    def test_format_sse_multi_line_data(self) -> None:
+        out = _format_sse("token", "line1\nline2")
+        assert out == "event: token\ndata: line1\ndata: line2\n\n"
+
+    def test_format_sse_done_marker(self) -> None:
+        assert _format_sse_done() == "data: [DONE]\n\n"
+
+    def test_meta_payload_includes_citations_and_intent(self) -> None:
+        payload = _meta_payload(
+            citations=[Citation("docs/x.md", "X", 0.2)],
+            intent="signal_health",
+            suggestions=["Check trust gate"],
+            data_cards=[{"label": "EMQ", "value": "0.95"}],
+            fallback_message=None,
+        )
+        body = json.loads(payload)
+        assert body["intent"] == "signal_health"
+        assert body["citations"] == [
+            {"source_path": "docs/x.md", "title": "X", "distance": 0.2}
+        ]
+        assert "fallback_message" not in body  # only present when set
+
+    def test_meta_payload_includes_fallback_when_present(self) -> None:
+        payload = _meta_payload(
+            citations=[],
+            intent="x",
+            suggestions=[],
+            data_cards=[],
+            fallback_message="template text",
+        )
+        body = json.loads(payload)
+        assert body["fallback_message"] == "template text"
+
+
+# =============================================================================
+# Off-paths
+# =============================================================================
+
+
+class TestStreamOffPaths:
+    @pytest.mark.asyncio
+    async def test_llm_disabled_emits_meta_with_fallback_then_done(self) -> None:
+        with _patch_settings(copilot_llm_enabled=False):
+            chunks = await _collect(
+                stream_llm_message(
+                    message="hi",
+                    user_name="X",
+                    metrics=None,
+                    health_data=None,
+                    anomaly_data=None,
+                    intent="greeting",
+                    suggestions=[],
+                    data_cards=[],
+                    fallback_message="Hi! Template here.",
+                )
+            )
+        joined = "".join(chunks)
+        assert "event: meta" in joined
+        assert "Hi! Template here." in joined
+        assert joined.endswith("data: [DONE]\n\n")
+        assert "event: token" not in joined
+
+    @pytest.mark.asyncio
+    async def test_no_anthropic_key_emits_meta_with_fallback(self) -> None:
+        with _patch_settings(anthropic_api_key=None):
+            chunks = await _collect(
+                stream_llm_message(
+                    message="hi",
+                    user_name="X",
+                    metrics=None,
+                    health_data=None,
+                    anomaly_data=None,
+                    intent="greeting",
+                    suggestions=[],
+                    data_cards=[],
+                    fallback_message="template",
+                )
+            )
+        joined = "".join(chunks)
+        assert "fallback_message" in joined
+        assert "event: token" not in joined
+
+
+# =============================================================================
+# Happy path
+# =============================================================================
+
+
+class TestStreamHappyPath:
+    @pytest.mark.asyncio
+    async def test_streams_tokens_then_meta_then_done(self) -> None:
+        fake = _FakeStream(tokens=["Hello", " world", "."])
+        client = _fake_anthropic_client(fake)
+
+        with (
+            _patch_settings(),
+            patch("anthropic.AsyncAnthropic", return_value=client),
+            patch(
+                "app.services.agents.copilot_llm._retrieve_docs",
+                new=AsyncMock(return_value=([], [])),
+            ),
+        ):
+            chunks = await _collect(
+                stream_llm_message(
+                    message="Hi",
+                    user_name="X",
+                    metrics=None,
+                    health_data=None,
+                    anomaly_data=None,
+                    intent="greeting",
+                    suggestions=["Try this"],
+                    data_cards=[{"label": "ROAS", "value": "4.2x"}],
+                    fallback_message="template",
+                )
+            )
+
+        text = "".join(chunks)
+        # Tokens come first.
+        assert text.index("event: token\ndata: Hello") < text.index("event: meta")
+        # Three token events.
+        assert text.count("event: token") == 3
+        # Then exactly one meta.
+        assert text.count("event: meta") == 1
+        # Then [DONE].
+        assert text.endswith("data: [DONE]\n\n")
+        # Success path: fallback_message NOT in the meta payload.
+        assert "fallback_message" not in text
+
+    @pytest.mark.asyncio
+    async def test_meta_carries_citations_from_retrieval(self) -> None:
+        fake = _FakeStream(tokens=["Answer."])
+        client = _fake_anthropic_client(fake)
+
+        async def _retrieve(*_args: Any, **_kwargs: Any) -> tuple:
+            return (
+                [{"source_path": "docs/x.md", "title": "X » Body", "content": "..."}],
+                [Citation("docs/x.md", "X » Body", 0.18)],
+            )
+
+        with (
+            _patch_settings(copilot_rag_enabled=True, openai_api_key="sk-test"),
+            patch("anthropic.AsyncAnthropic", return_value=client),
+            patch(
+                "app.services.agents.copilot_llm_stream._retrieve_docs",
+                side_effect=_retrieve,
+            ),
+        ):
+            chunks = await _collect(
+                stream_llm_message(
+                    message="Q",
+                    user_name="X",
+                    metrics=None,
+                    health_data=None,
+                    anomaly_data=None,
+                    intent="x",
+                    suggestions=[],
+                    data_cards=[],
+                    fallback_message="fb",
+                )
+            )
+
+        text = "".join(chunks)
+        # Pull out the meta JSON body.
+        meta_event = [
+            block for block in text.split("\n\n")
+            if "event: meta" in block
+        ][0]
+        body_line = [
+            line[len("data: "):]
+            for line in meta_event.split("\n")
+            if line.startswith("data: ")
+        ][0]
+        body = json.loads(body_line)
+        assert body["citations"] == [
+            {"source_path": "docs/x.md", "title": "X » Body", "distance": 0.18}
+        ]
+
+
+# =============================================================================
+# Failure paths
+# =============================================================================
+
+
+class TestStreamFailures:
+    @pytest.mark.asyncio
+    async def test_anthropic_error_emits_error_then_meta_then_done(self) -> None:
+        fake = _FakeStream(tokens=["nope"], raise_during=True)
+        client = _fake_anthropic_client(fake)
+
+        with (
+            _patch_settings(),
+            patch("anthropic.AsyncAnthropic", return_value=client),
+            patch(
+                "app.services.agents.copilot_llm._retrieve_docs",
+                new=AsyncMock(return_value=([], [])),
+            ),
+        ):
+            chunks = await _collect(
+                stream_llm_message(
+                    message="Q",
+                    user_name="X",
+                    metrics=None,
+                    health_data=None,
+                    anomaly_data=None,
+                    intent="x",
+                    suggestions=[],
+                    data_cards=[],
+                    fallback_message="template",
+                )
+            )
+
+        text = "".join(chunks)
+        assert "event: error\ndata: stream_error" in text
+        # Meta is emitted with the fallback because zero tokens streamed.
+        assert "fallback_message" in text
+        assert "template" in text
+        assert text.endswith("data: [DONE]\n\n")
+
+    @pytest.mark.asyncio
+    async def test_partial_stream_meta_omits_fallback(self) -> None:
+        # First token succeeds; raise on the second.
+        class _PartialStream(_FakeStream):
+            async def _iter(self) -> AsyncIterator[str]:
+                yield self.tokens[0]
+                raise RuntimeError("midway")
+
+        fake = _PartialStream(tokens=["Hel", "lo"])
+        client = _fake_anthropic_client(fake)
+
+        with (
+            _patch_settings(),
+            patch("anthropic.AsyncAnthropic", return_value=client),
+            patch(
+                "app.services.agents.copilot_llm._retrieve_docs",
+                new=AsyncMock(return_value=([], [])),
+            ),
+        ):
+            chunks = await _collect(
+                stream_llm_message(
+                    message="Q",
+                    user_name="X",
+                    metrics=None,
+                    health_data=None,
+                    anomaly_data=None,
+                    intent="x",
+                    suggestions=[],
+                    data_cards=[],
+                    fallback_message="template",
+                )
+            )
+
+        text = "".join(chunks)
+        # One token did stream...
+        assert "event: token\ndata: Hel" in text
+        # ...and the failure path runs but does NOT include fallback_message
+        # because the dashboard already has a partial bubble to show.
+        assert "fallback_message" not in text
+        assert "event: error" in text

--- a/docs/06-deploy/copilot-rag-indexing.md
+++ b/docs/06-deploy/copilot-rag-indexing.md
@@ -1,11 +1,13 @@
-# Activation Checklist — Copilot RAG (Phases D-1 + D-2)
+# Activation Checklist — Copilot RAG (Phases D-1 + D-2 + D-3)
 
-The Copilot RAG bridge is shipped in three pieces. This doc covers
-**Phase D Part 1 — indexing infrastructure** and **Phase D Part 2 —
-bridge wiring + citations**. The bridge is now active; toggling
-`COPILOT_RAG_ENABLED=true` will retrieve docs and pass them to Claude.
+The Copilot RAG bridge is shipped complete. This doc covers all three
+parts:
 
-**Phase D Part 3** (SSE streaming) is a separate PR.
+- **Part 1** — pgvector + indexing infrastructure
+- **Part 2** — RAG retrieval wired into the bridge with citations
+- **Part 3** — SSE streaming endpoint (`POST /copilot/chat/stream`)
+  with frontend token-by-token rendering and graceful fallback to
+  the buffered `POST /copilot/chat` endpoint on stream failure.
 
 ## What this PR ships
 
@@ -137,9 +139,18 @@ auto-cleaned — drop them manually:
 DELETE FROM copilot_doc_chunks WHERE source_path = 'docs/old-thing.md';
 ```
 
-## Out of scope (deferred)
+## Streaming notes (Part 3)
 
-- Streaming responses + frontend EventSource — PR 3.
+The frontend tries `POST /copilot/chat/stream` first and falls back to
+`POST /copilot/chat` on any failure (network, 5xx, malformed SSE).
+No env var to enable — streaming is automatic when the chat endpoint
+is reachable. SSE wire format is documented in
+`backend/app/services/agents/copilot_llm_stream.py`.
+
+If you front the API with Cloudflare or nginx, ensure proxy buffering
+is disabled for `/copilot/chat/stream` (the endpoint sets
+`X-Accel-Buffering: no` and `Cache-Control: no-cache, no-transform`,
+but some configs override).
 - Auto-reindex on docs/ edits — would need a CI job or git hook.
 - Per-tenant docs (e.g. tenant-uploaded help articles) — current
   scope is platform docs only.

--- a/frontend/src/api/copilot.ts
+++ b/frontend/src/api/copilot.ts
@@ -65,11 +65,139 @@ export const copilotApi = {
 };
 
 // =============================================================================
+// Streaming
+// =============================================================================
+
+/**
+ * Callback shape for the streaming consumer below.
+ *
+ * The bridge emits `session` once, then zero-or-more `token` events,
+ * optionally one `error` event (timeout / SDK failure), then exactly
+ * one `meta` event before `[DONE]`. If `meta.fallback_message` is
+ * present, the dashboard should *replace* the streamed bubble with
+ * `fallback_message` — the LLM produced nothing usable.
+ */
+export interface CopilotStreamHandlers {
+  onSession?: (sessionId: string) => void;
+  onToken: (text: string) => void;
+  onMeta: (meta: {
+    intent: string;
+    suggestions: string[];
+    data_cards: CopilotDataCard[];
+    citations: CopilotCitation[];
+    fallback_message?: string | null;
+  }) => void;
+  onError?: (reason: string) => void;
+  onDone?: () => void;
+}
+
+/**
+ * POST /copilot/chat/stream and parse the SSE stream.
+ *
+ * Throws on network failure before the first byte; otherwise drains
+ * the stream and resolves when [DONE] is seen. EventSource isn't
+ * usable here because the spec is GET-only and we need POST + auth
+ * headers, so we hand-roll a minimal parser over fetch's
+ * ReadableStream.
+ */
+export async function streamCopilotMessage(
+  request: CopilotMessageRequest,
+  handlers: CopilotStreamHandlers,
+  options: { signal?: AbortSignal } = {}
+): Promise<void> {
+  const baseURL =
+    apiClient.defaults?.baseURL ??
+    (import.meta.env.VITE_API_URL as string | undefined) ??
+    '';
+  const token = sessionStorage.getItem('access_token') ?? '';
+
+  const response = await fetch(`${baseURL}/copilot/chat/stream`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(request),
+    signal: options.signal,
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Copilot stream failed: HTTP ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const dispatch = (rawEvent: string) => {
+    if (!rawEvent.trim()) return;
+    let eventName = 'message';
+    const dataLines: string[] = [];
+    for (const line of rawEvent.split('\n')) {
+      if (line.startsWith('event: ')) {
+        eventName = line.slice('event: '.length).trim();
+      } else if (line.startsWith('data: ')) {
+        dataLines.push(line.slice('data: '.length));
+      }
+    }
+    const data = dataLines.join('\n');
+
+    if (data === '[DONE]') {
+      handlers.onDone?.();
+      return;
+    }
+    switch (eventName) {
+      case 'session':
+        handlers.onSession?.(data);
+        break;
+      case 'token':
+        handlers.onToken(data);
+        break;
+      case 'meta':
+        try {
+          const parsed = JSON.parse(data);
+          handlers.onMeta({
+            intent: parsed.intent ?? 'unknown',
+            suggestions: parsed.suggestions ?? [],
+            data_cards: parsed.data_cards ?? [],
+            citations: parsed.citations ?? [],
+            fallback_message: parsed.fallback_message ?? null,
+          });
+        } catch {
+          handlers.onError?.('meta_parse_error');
+        }
+        break;
+      case 'error':
+        handlers.onError?.(data);
+        break;
+      // 'message' (no event:) is unused by our backend; ignore.
+    }
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    // Events are delimited by a blank line — i.e. \n\n.
+    let separator: number;
+    while ((separator = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, separator);
+      buffer = buffer.slice(separator + 2);
+      dispatch(rawEvent);
+    }
+  }
+  // Flush any trailing event the server didn't terminate (defensive).
+  if (buffer.trim()) {
+    dispatch(buffer);
+  }
+}
+
+// =============================================================================
 // Hooks
 // =============================================================================
 
 /**
- * Send a message to the AI Copilot
+ * Send a message to the AI Copilot (non-streaming)
  */
 export function useCopilotChat() {
   return useMutation({

--- a/frontend/src/components/dashboard/CopilotChat.tsx
+++ b/frontend/src/components/dashboard/CopilotChat.tsx
@@ -14,8 +14,8 @@ import {
   BookOpen,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useCopilotChat } from '@/api/copilot';
-import type { CopilotMessage, CopilotDataCard } from '@/api/copilot';
+import { useCopilotChat, streamCopilotMessage } from '@/api/copilot';
+import type { CopilotMessage, CopilotDataCard, CopilotCitation } from '@/api/copilot';
 
 function DataCard({ card }: { card: CopilotDataCard }) {
   const statusColors: Record<string, string> = {
@@ -152,6 +152,7 @@ export function CopilotChat() {
   const [messages, setMessages] = useState<CopilotMessage[]>([]);
   const [input, setInput] = useState('');
   const [sessionId, setSessionId] = useState<string | undefined>();
+  const [isStreaming, setIsStreaming] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -194,7 +195,7 @@ export function CopilotChat() {
   }, [isOpen, messages.length]);
 
   const sendMessage = async (text: string) => {
-    if (!text.trim() || chatMutation.isPending) return;
+    if (!text.trim() || chatMutation.isPending || isStreaming) return;
 
     const userMsg: CopilotMessage = {
       id: `user-${Date.now()}`,
@@ -205,6 +206,58 @@ export function CopilotChat() {
 
     setMessages((prev) => [...prev, userMsg]);
     setInput('');
+
+    // Try the streaming endpoint first. On any failure (network,
+    // 5xx, malformed SSE) we fall back to the buffered /chat call.
+    const assistantId = `asst-${Date.now()}`;
+    setIsStreaming(true);
+
+    let streamedContent = '';
+    const seedAssistant: CopilotMessage = {
+      id: assistantId,
+      role: 'assistant',
+      content: '',
+      timestamp: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, seedAssistant]);
+
+    const updateStreamed = (patch: Partial<CopilotMessage>) => {
+      setMessages((prev) => prev.map((m) => (m.id === assistantId ? { ...m, ...patch } : m)));
+    };
+
+    try {
+      await streamCopilotMessage(
+        { message: text.trim(), session_id: sessionId },
+        {
+          onSession: (sid) => setSessionId(sid),
+          onToken: (chunk) => {
+            streamedContent += chunk;
+            updateStreamed({ content: streamedContent });
+          },
+          onMeta: (meta) => {
+            const finalContent = meta.fallback_message ?? streamedContent.trim() ?? '';
+            updateStreamed({
+              content: finalContent || meta.fallback_message || '',
+              suggestions: meta.suggestions,
+              data_cards: meta.data_cards,
+              intent: meta.intent,
+              citations: meta.citations as CopilotCitation[],
+            });
+          },
+          onDone: () => setIsStreaming(false),
+          onError: () => {
+            // Don't set isStreaming false here — we wait for meta + done
+            // so the dashboard can swap in fallback_message cleanly.
+          },
+        }
+      );
+      return;
+    } catch {
+      // Stream failed before the first byte. Roll back the empty
+      // assistant bubble and fall through to the buffered path.
+      setMessages((prev) => prev.filter((m) => m.id !== assistantId));
+      setIsStreaming(false);
+    }
 
     try {
       const response = await chatMutation.mutateAsync({
@@ -346,11 +399,11 @@ export function CopilotChat() {
                 placeholder="Ask about your campaigns..."
                 aria-label="Ask about your campaigns"
                 className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground/60 outline-none py-1.5"
-                disabled={chatMutation.isPending}
+                disabled={chatMutation.isPending || isStreaming}
               />
               <button
                 type="submit"
-                disabled={!input.trim() || chatMutation.isPending}
+                disabled={!input.trim() || chatMutation.isPending || isStreaming}
                 aria-label="Send message"
                 className={cn(
                   'p-1.5 rounded-lg transition-colors',


### PR DESCRIPTION
Final Phase D PR. The Copilot bubble now renders Claude's response as it generates, with citations + suggestions + data cards arriving once the stream completes. Falls back transparently to the buffered endpoint on any stream failure.

Backend
- New app/services/agents/copilot_llm_stream.py with stream_llm_message() async generator yielding SSE-formatted strings:
    event: token   data: <text fragment>
    event: meta    data: {citations, intent, suggestions, data_cards,
                          fallback_message?}
    event: error   data: <reason>           (optional)
    data: [DONE]
- New POST /copilot/chat/stream endpoint via FastAPI StreamingResponse.
  Reuses _gather_context() (extracted from /chat to dedupe) and the
  same RAG retrieval path as PR2.
- Sets Cache-Control: no-cache, X-Accel-Buffering: no so Cloudflare
  and nginx don't batch tokens.
- Failure semantics preserved: timeout / SDK error emits an `error`
  event, then meta with fallback_message populated when zero tokens
  streamed (so the dashboard swaps in the keyword template), or
  meta without fallback when at least one token arrived.

Frontend
- New streamCopilotMessage() in api/copilot.ts — hand-rolled SSE parser over fetch + ReadableStream (EventSource is GET-only). Dispatches onSession / onToken / onMeta / onError / onDone.
- CopilotChat.tsx tries the stream first; on any failure rolls back the empty bubble and falls through to the existing /chat call so no behaviour regresses for clients that can't stream.
- New isStreaming state gates the input + send button while a stream is in flight.

Tests
- backend/tests/unit/test_copilot_llm_stream.py — 11 tests covering SSE wire format, off-paths (LLM disabled / no key), happy path (tokens then meta then [DONE]), citations propagation, timeout behaviour, partial-stream failure (no fallback in meta), full failure (fallback in meta).

Suite: backend 44/44 (11 streaming + 12 bridge + 21 doc_index); frontend 992/992; tsc clean.

Activation: no new env vars. The frontend probes the stream endpoint on every send and falls back to /chat on failure, so this is a zero-config upgrade. To verify in production, watch the Network tab — /copilot/chat/stream should show `text/event-stream` content-type and tokens streaming.

Phase D is complete. Three PRs:
  PR1 #271 — pgvector + indexing
  PR2 #272 — RAG retrieval + citations
  PR3 (this) — SSE streaming

## Summary
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues
<!-- Link related issues: Fixes #123, Relates to #456 -->

## Changes Made
<!-- Bullet list of specific changes -->
-

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing completed

## Trust Engine Impact
<!-- If this PR affects the Trust Engine, describe the impact -->
- [ ] No Trust Engine impact
- [ ] Signal collection affected
- [ ] Health calculation affected
- [ ] Trust gate logic affected
- [ ] Automation execution affected

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No sensitive data exposed (API keys, PII, etc.)
- [ ] Database migrations included (if needed)
