### PR TITLE
fix(security): close P0 cross-tenant isolation gaps

### DIFF
--- a/backend/app/api/v1/endpoints/analytics_ai.py
+++ b/backend/app/api/v1/endpoints/analytics_ai.py
@@ -269,7 +269,12 @@ async def get_ai_recommendations(
     - Alerts (anomalies and issues)
     - Insights (opportunities)
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Get campaigns
     result = await db.execute(
@@ -360,7 +365,12 @@ async def get_analytics_kpis(
     """
     Get analytics KPIs summary for the dashboard.
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Get campaigns
     result = await db.execute(

--- a/backend/app/api/v1/endpoints/copilot.py
+++ b/backend/app/api/v1/endpoints/copilot.py
@@ -200,7 +200,12 @@ async def copilot_chat(
     The copilot analyzes the user's query, fetches relevant dashboard data,
     and generates a contextual response with suggestions and data cards.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = getattr(user, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
     _, first_name = _resolve_user_name(user)
 
     session_id = request.session_id or str(uuid4())
@@ -296,7 +301,12 @@ async def copilot_chat_stream(
     tokens), and renders citations + suggestions + data_cards from the
     `meta` payload once the stream completes.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = getattr(user, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
     _, first_name = _resolve_user_name(user)
     session_id = request.session_id or str(uuid4())
 

--- a/backend/app/api/v1/endpoints/newsletter.py
+++ b/backend/app/api/v1/endpoints/newsletter.py
@@ -230,7 +230,10 @@ async def list_templates(
     is_active: bool = True,
 ) -> list[TemplateResponse]:
     """List newsletter templates."""
-    query = select(NewsletterTemplate).where(NewsletterTemplate.is_active == is_active)
+    query = select(NewsletterTemplate).where(
+        NewsletterTemplate.is_active == is_active,
+        NewsletterTemplate.tenant_id == current_user.tenant_id,
+    )
     if category:
         query = query.where(NewsletterTemplate.category == category)
     query = query.order_by(NewsletterTemplate.updated_at.desc()).limit(1000)
@@ -254,6 +257,7 @@ async def create_template(
         content_html=data.content_html,
         content_json=data.content_json,
         category=data.category,
+        tenant_id=current_user.tenant_id,
         created_by_user_id=current_user.id,
     )
     db.add(template)
@@ -271,7 +275,10 @@ async def update_template(
 ) -> TemplateResponse:
     """Update an existing template."""
     result = await db.execute(
-        select(NewsletterTemplate).where(NewsletterTemplate.id == template_id)
+        select(NewsletterTemplate).where(
+            NewsletterTemplate.id == template_id,
+            NewsletterTemplate.tenant_id == current_user.tenant_id,
+        )
     )
     template = result.scalar_one_or_none()
     if not template:
@@ -293,7 +300,10 @@ async def delete_template(
 ) -> dict:
     """Delete a template (soft-delete by setting is_active=False)."""
     result = await db.execute(
-        select(NewsletterTemplate).where(NewsletterTemplate.id == template_id)
+        select(NewsletterTemplate).where(
+            NewsletterTemplate.id == template_id,
+            NewsletterTemplate.tenant_id == current_user.tenant_id,
+        )
     )
     template = result.scalar_one_or_none()
     if not template:
@@ -316,8 +326,12 @@ async def list_campaigns(
     offset: int = Query(default=0, ge=0),
 ) -> CampaignListResponse:
     """List newsletter campaigns with optional status filter."""
-    query = select(NewsletterCampaign)
-    count_query = select(func.count(NewsletterCampaign.id))
+    query = select(NewsletterCampaign).where(
+        NewsletterCampaign.tenant_id == current_user.tenant_id
+    )
+    count_query = select(func.count(NewsletterCampaign.id)).where(
+        NewsletterCampaign.tenant_id == current_user.tenant_id
+    )
 
     if status:
         query = query.where(NewsletterCampaign.status == status)
@@ -356,6 +370,7 @@ async def create_campaign(
         reply_to_email=data.reply_to_email,
         audience_filters=data.audience_filters,
         status=CampaignStatus.DRAFT.value,
+        tenant_id=current_user.tenant_id,
         created_by_user_id=current_user.id,
     )
 
@@ -376,7 +391,10 @@ async def get_campaign(
 ) -> CampaignResponse:
     """Get campaign details."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -393,7 +411,10 @@ async def update_campaign(
 ) -> CampaignResponse:
     """Update a draft campaign."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -421,7 +442,10 @@ async def delete_campaign(
 ) -> dict:
     """Delete a draft campaign."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -442,7 +466,10 @@ async def duplicate_campaign(
 ) -> CampaignResponse:
     """Clone an existing campaign as a new draft."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     original = result.scalar_one_or_none()
     if not original:
@@ -461,6 +488,7 @@ async def duplicate_campaign(
         audience_filters=original.audience_filters,
         status=CampaignStatus.DRAFT.value,
         total_recipients=original.total_recipients,
+        tenant_id=current_user.tenant_id,
         created_by_user_id=current_user.id,
     )
     db.add(clone)
@@ -477,7 +505,10 @@ async def send_campaign(
 ) -> dict:
     """Queue campaign for immediate send."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -520,7 +551,10 @@ async def schedule_campaign(
 ) -> dict:
     """Schedule campaign for future send."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -550,7 +584,10 @@ async def cancel_campaign(
 ) -> dict:
     """Cancel a scheduled or sending campaign."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -572,7 +609,10 @@ async def send_test_email(
 ) -> dict:
     """Send test email to specified addresses."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:
@@ -607,7 +647,10 @@ async def campaign_analytics(
 ) -> AnalyticsResponse:
     """Get detailed analytics for a campaign."""
     result = await db.execute(
-        select(NewsletterCampaign).where(NewsletterCampaign.id == campaign_id)
+        select(NewsletterCampaign).where(
+            NewsletterCampaign.id == campaign_id,
+            NewsletterCampaign.tenant_id == current_user.tenant_id,
+        )
     )
     campaign = result.scalar_one_or_none()
     if not campaign:

--- a/backend/app/api/v1/endpoints/predictions.py
+++ b/backend/app/api/v1/endpoints/predictions.py
@@ -136,7 +136,12 @@ async def get_live_predictions(
     - Per-campaign health scores and recommendations
     - Active alerts for underperforming campaigns
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Check for cached predictions (less than 30 mins old)
     if not refresh:
@@ -256,7 +261,12 @@ async def get_campaign_prediction(
     """
     Get detailed predictions and recommendations for a specific campaign.
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Get campaign
     result = await db.execute(
@@ -308,7 +318,12 @@ async def get_prediction_alerts(
     """
     Get prediction-based alerts for campaigns.
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Get recent alerts from predictions
     result = await db.execute(
@@ -383,7 +398,12 @@ async def trigger_prediction_refresh(
     Trigger a refresh of live predictions for the tenant.
     Queues a background task.
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Queue prediction task
     task = run_live_predictions.delay(tenant_id)
@@ -406,7 +426,12 @@ async def get_budget_optimization(
     Get budget optimization recommendations across all campaigns.
     Returns suggested budget reallocation for maximum ROAS.
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Get campaigns
     result = await db.execute(
@@ -460,7 +485,12 @@ async def get_budget_scenarios(
     Get budget change scenarios for a campaign.
     Shows predicted ROAS and revenue at different budget levels.
     """
-    tenant_id = getattr(request.state, "tenant_id", 1)
+    tenant_id = getattr(request.state, "tenant_id", None)
+    if tenant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
 
     # Get campaign
     result = await db.execute(

--- a/backend/app/api/v1/endpoints/tenants.py
+++ b/backend/app/api/v1/endpoints/tenants.py
@@ -48,6 +48,26 @@ def require_admin(request: Request) -> int:
     return user_id
 
 
+def require_superadmin(request: Request) -> int:
+    """Verify user has platform superadmin role (cross-tenant operations)."""
+    user_role = getattr(request.state, "role", None)
+    user_id = getattr(request.state, "user_id", None)
+
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    if user_role != UserRole.SUPERADMIN.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Superadmin access required",
+        )
+
+    return user_id
+
+
 @router.get("", response_model=APIResponse[List[TenantResponse]])
 async def list_tenants(
     request: Request,
@@ -157,7 +177,7 @@ async def get_tenant(
     user_tenant_id = getattr(request.state, "tenant_id", None)
 
     # Non-admin can only view their own tenant
-    if user_role not in (UserRole.ADMIN.value, UserRole.SUPERADMIN.value) and tenant_id != user_tenant_id:
+    if user_role != UserRole.SUPERADMIN.value and tenant_id != user_tenant_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied",
@@ -201,9 +221,9 @@ async def create_tenant(
 ):
     """
     Create a new tenant.
-    Requires admin role.
+    Requires superadmin role (platform-level cross-tenant operation).
     """
-    require_admin(request)
+    require_superadmin(request)
 
     # Check for duplicate slug
     result = await db.execute(
@@ -287,7 +307,7 @@ async def update_tenant(
         )
 
     # Non-admin can only update their own tenant
-    if user_role not in (UserRole.ADMIN.value, UserRole.SUPERADMIN.value) and tenant_id != user_tenant_id:
+    if user_role != UserRole.SUPERADMIN.value and tenant_id != user_tenant_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied",
@@ -347,9 +367,9 @@ async def delete_tenant(
 ):
     """
     Soft delete a tenant.
-    Requires admin role.
+    Requires superadmin role (platform-level cross-tenant operation).
     """
-    require_admin(request)
+    require_superadmin(request)
 
     user_tenant_id = getattr(request.state, "tenant_id", None)
 
@@ -396,7 +416,7 @@ async def get_tenant_users(
     user_tenant_id = getattr(request.state, "tenant_id", None)
 
     # Non-admin can only view their own tenant
-    if user_role not in (UserRole.ADMIN.value, UserRole.SUPERADMIN.value) and tenant_id != user_tenant_id:
+    if user_role != UserRole.SUPERADMIN.value and tenant_id != user_tenant_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied",
@@ -443,9 +463,9 @@ async def update_tenant_plan(
 ):
     """
     Update tenant subscription plan.
-    Requires admin role.
+    Requires superadmin role (platform-level cross-tenant operation).
     """
-    require_admin(request)
+    require_superadmin(request)
 
     result = await db.execute(
         select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)
@@ -508,9 +528,9 @@ async def update_tenant_features(
 ):
     """
     Update tenant feature flags.
-    Requires admin role.
+    Requires superadmin role (platform-level cross-tenant operation).
     """
-    require_admin(request)
+    require_superadmin(request)
 
     result = await db.execute(
         select(Tenant).where(Tenant.id == tenant_id, Tenant.is_deleted == False)


### PR DESCRIPTION
## P0 Security: Close cross-tenant isolation gaps

Remediation for the highest-severity findings in the system audit (PR #292). Fixes **three classes of cross-tenant data exposure**.

### 1. Newsletter IDOR (critical)
`newsletter.py` campaign/template endpoints ignored the `tenant_id` column entirely — any authenticated user could **read / send / delete / duplicate any tenant's campaigns** by ID.
- Added `tenant_id == current_user.tenant_id` to every authenticated query (9 campaign by-id selects + list/count, 2 template by-id selects + list).
- Set `tenant_id` on create-template, create-campaign, and duplicate.
- **Left public tracking/unsubscribe routes unscoped** (they resolve a campaign from a signed public URL and have no `current_user`) — verified no `current_user` reference leaked into them.

### 2. `tenants.py` cross-tenant admin access (high)
`get_tenant` / `update_tenant` / `get_tenant_users` only required `ADMIN` role, then operated on an arbitrary path `tenant_id` — so a **tenant ADMIN of Tenant A could read/modify Tenant B**.
- Cross-tenant access now requires `SUPERADMIN`; non-superadmins are restricted to their own tenant.
- `create` / `delete` / `update_plan` / `update_features` are platform operations → now `require_superadmin` (prevents a tenant admin **self-granting entitlements** or **deleting other tenants**). Added a `require_superadmin` helper.

### 3. `default 1` tenant fallback (high)
`predictions.py` (6 sites), `analytics_ai.py` (2), `copilot.py` (2) defaulted `tenant_id` to **1** on missing context — cross-tenant leak / mis-attribution. Replaced with an explicit **401**.

### Verification
- `ast.parse` ✅ and `ruff check` ✅ on all 5 files.
- Test suite **not run locally** (`fastapi` not installed in this environment) — CI will exercise it.

### Not included (follow-ups)
- **MFA-at-login enforcement** (the remaining P0) — needs a login-flow design decision (two-step `mfa_required` response + frontend step-2 UI); will raise separately.
- Integration tests for these isolation cases (couldn't run locally; recommend adding to `tests/integration/test_tenant_isolation.py`).
- A pre-existing **local hook false-positive**: `.claude/hooks/rule-check.sh` flags the 1×1 tracking-pixel GIF base64 in `newsletter.py` as a "vendor API token" (the `EAA[a-zA-Z0-9]{20,}` Meta-token regex matches it by coincidence). Not a real credential; pre-exists on `main`. Left the hook untouched.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_