### PR TITLE
fix: repair 7 runtime crash bugs (NameError/SyntaxError)

### DIFF
--- a/backend/app/api/v1/endpoints/campaign_builder.py
+++ b/backend/app/api/v1/endpoints/campaign_builder.py
@@ -28,7 +28,9 @@ from app.models.campaign_builder import (
 )
 from app.core.security import require_permission
 from app.schemas.response import APIResponse, PaginatedResponse
+from app.core.logging import get_logger
 
+logger = get_logger(__name__)
 router = APIRouter(prefix="/tenant/{tenant_id}", tags=["campaign-builder"])
 
 

--- a/backend/app/api/v1/endpoints/emq_v2.py
+++ b/backend/app/api/v1/endpoints/emq_v2.py
@@ -20,7 +20,7 @@ from datetime import date, datetime, timedelta
 from typing import List, Optional
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.deps import get_current_user, require_superadmin

--- a/backend/app/api/v1/endpoints/trust_layer.py
+++ b/backend/app/api/v1/endpoints/trust_layer.py
@@ -55,7 +55,7 @@ async def get_signal_health(
         raise HTTPException(
             status_code=403,
             detail="Signal health feature is not enabled for this tenant"
-        ).limit(1000)
+        )
 
     service = SignalHealthService(db)
     data = await service.get_signal_health(tenant_id, target_date)

--- a/backend/app/services/competitor_scraper.py
+++ b/backend/app/services/competitor_scraper.py
@@ -240,7 +240,7 @@ async def scrape_website(domain: str) -> CompetitorScanResult:
             follow_redirects=True,
             timeout=REQUEST_TIMEOUT,
             headers={"User-Agent": USER_AGENT},
-            verify=True, - Some sites have cert issues
+            verify=True,  # Some sites have cert issues
         ) as client:
             response = await client.get(url)
             response.raise_for_status()

--- a/backend/app/services/offline_conversion_service.py
+++ b/backend/app/services/offline_conversion_service.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from enum import Enum
 import asyncio
 import httpx
+import statistics
 
 from app.core.logging import get_logger
 from app.services.capi.pii_hasher import PIIHasher

--- a/backend/app/services/profit/cogs_service.py
+++ b/backend/app/services/profit/cogs_service.py
@@ -11,7 +11,7 @@ Features:
 - Historical COGS tracking
 """
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, BinaryIO
 from uuid import UUID
 import csv
@@ -94,7 +94,7 @@ class COGSService:
                     ),
                 )
             )
-            .values(end_date=effective_date - datetime.timedelta(days=1))
+            .values(end_date=effective_date - timedelta(days=1))
         )
 
         # Calculate total COGS

--- a/backend/app/stratum/core/autopilot.py
+++ b/backend/app/stratum/core/autopilot.py
@@ -694,7 +694,7 @@ class AutopilotEngine:
                 gate_results = []
                 if rule_result.triggered and rule_result.actions:
                     for action in rule_result.actions:
-                        gate_result = self.trust_gate.evaluate(action, signal_health)
+                        gate_result = self.trust_gate.evaluate(signal_health, action)
                         gate_results.append(gate_result)
 
                         # Execute if auto_execute is on and approved
@@ -787,7 +787,7 @@ class TrustGatedAutopilot:
         )
 
         # Evaluate through trust gate
-        result = self.trust_gate.evaluate(action, signal_health)
+        result = self.trust_gate.evaluate(signal_health, action)
 
         # PASS means the trust gate approved execution based on signal health
         can_proceed = result.decision == GateDecision.PASS

--- a/backend/app/stratum/examples/example_usage.py
+++ b/backend/app/stratum/examples/example_usage.py
@@ -131,7 +131,7 @@ async def example_meta_integration():
     # Evaluate through trust gate
     logger.info("\nStep 8: Evaluate through trust gate")
     gate = TrustGate()
-    result = gate.evaluate(action, signal_health)
+    result = gate.evaluate(signal_health, action)
     logger.info(f"  Gate Decision: {result.decision.value.upper()}")
     logger.info(f"  Reason: {result.reason}")
 


### PR DESCRIPTION
## Fix 7 runtime crash bugs (NameError / SyntaxError) on real code paths

Remediation for the P1 crash-bug cluster from the system audit (PR #292). Each of these fails at runtime / import time.

| Bug | File:line | Effect |
|---|---|---|
| Stray `-` instead of comment | `competitor_scraper.py:243` (`verify=True, - Some sites...`) | **SyntaxError — module unimportable**; all scraping dead |
| `status` not imported | `emq_v2.py` (HTTP_501 usage) | `NameError` on `update_playbook_item` |
| `statistics` not imported | `offline_conversion_service.py:983` | `NameError` in `MatchRatePredictor.predict` when history exists |
| `datetime.timedelta` (invalid) | `profit/cogs_service.py:97` | `AttributeError` on every COGS update that closes a prior margin period |
| `logger` undefined | `campaign_builder.py:301` | `NameError` on token-refresh error path |
| `.limit(1000)` on a raised `HTTPException` | `trust_layer.py:58` | `AttributeError` instead of clean 403 when `signal_health` flag is off |
| Reversed args to `TrustGate.evaluate` | `stratum/core/autopilot.py:697,790` (+ example) | Wrong-type args (`evaluate(signal_health, action)`) → wrong decisions / errors |

### Notes
- `trust_layer.py:136` has a **legitimate** `.limit(1000)` on a SQL `select().order_by()` — left untouched. Only the one chained on `HTTPException` was a bug.
- `cogs_service.py` now imports `timedelta` and uses `timedelta(days=1)`.
- Also fixed the same reversed-args bug in `stratum/examples/example_usage.py` to stop copy-paste propagation.

### Verification
- `ast.parse` ✅ and `ruff check` ✅ on all 8 files (`competitor_scraper` now imports).
- Test suite **not run locally** (`fastapi` not installed in this env) — CI will exercise it.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_