### PR TITLE
fix(security): close P0-2 cross-tenant fallback with shared TenantContextDep

### DIFF
--- a/backend/app/api/v1/endpoints/advanced_analytics.py
+++ b/backend/app/api/v1/endpoints/advanced_analytics.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.deps import require_superadmin
 from app.core.logging import get_logger
 from app.db.session import get_async_session
 from app.models import Campaign, CampaignMetric
@@ -521,7 +522,11 @@ async def analyze_cohorts(
     )
 
 
-@router.post("/sql", response_model=APIResponse[SQLQueryResult])
+@router.post(
+    "/sql",
+    response_model=APIResponse[SQLQueryResult],
+    dependencies=[Depends(require_superadmin())],
+)
 async def execute_sql_query(
     request: SQLQueryRequest,
     req: Request,

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -30,7 +30,7 @@ from sqlalchemy import and_, desc, func, select, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.deps import CurrentUserDep, VerifiedUserDep
+from app.auth.deps import CurrentUserDep, VerifiedUserDep, require_tenant_id
 from app.core.logging import get_logger
 from app.db.session import get_async_session
 from app.models import (
@@ -1900,7 +1900,7 @@ async def get_morning_briefing(
     Aggregates overnight changes, signal health, recommendations,
     and top actions into a single glanceable briefing card.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
     today = date.today()
     yesterday = today - timedelta(days=1)
 
@@ -2177,7 +2177,7 @@ async def get_anomaly_narratives(
     with likely causes and recommended actions, identifies cross-metric
     correlations, and provides an executive summary with portfolio risk level.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
     today = date.today()
 
     # --- Build metric histories from campaign data (last 14 days) ---
@@ -2299,7 +2299,7 @@ async def get_signal_recovery(
     Analyzes EMQ score, event loss rate, API connectivity, and data
     freshness to identify degradation and recommend recovery steps.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Gather signal health indicators ──────────────────────────
@@ -2477,7 +2477,7 @@ async def get_predictive_budget(
     to recommend which campaigns to scale, reduce, or pause.
     Only auto-executes when signal health passes AND confidence > 85%.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Fetch campaign data ──────────────────────────────────
@@ -2600,7 +2600,7 @@ async def get_ai_report(
     with narrative insights, platform breakdowns, campaign highlights,
     trend analysis, and actionable recommendations.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Fetch current period campaigns ─────────────────────────
@@ -2697,7 +2697,7 @@ async def get_churn_prevention(
     recommendations. Scores each campaign across performance, spend trend,
     and engagement dimensions.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Fetch campaigns with sync status ───────────────────────
@@ -2806,7 +2806,7 @@ async def get_notifications_prioritized(
     is scored by urgency, impact, and actionability to produce a
     priority-ranked feed with suggested actions.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Fetch campaigns ─────────────────────────────────────────
@@ -2952,7 +2952,7 @@ async def get_cross_platform_optimizer(
     connected platforms and recommends optimal budget distribution based on
     the selected strategy (roas_max, balanced, volume_max).
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     # Validate strategy
     valid_strategies = ("roas_max", "balanced", "volume_max")
@@ -3055,7 +3055,7 @@ async def get_audience_lifecycle(
     distribution and generates automated audience sync recommendations
     based on stage transitions (anonymous → known → customer → churned).
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Fetch CDP profiles ──────────────────────────────────────
@@ -3239,7 +3239,7 @@ async def get_goal_tracking(
     ROAS, and conversion targets with pacing status, EOM projections,
     milestones, and AI-generated insights.
     """
-    tenant_id = getattr(user, "tenant_id", None) or 1
+    tenant_id = require_tenant_id(user)
 
     try:
         # ── Fetch campaigns ─────────────────────────────────────────

--- a/backend/app/api/v1/endpoints/newsletter.py
+++ b/backend/app/api/v1/endpoints/newsletter.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.deps import CurrentUserDep, get_current_user
+from app.auth.deps import CurrentUserDep, get_current_user, require_superadmin
 from app.base_models import LandingPageSubscriber, SubscriberStatus
 from app.db.session import get_async_session
 from app.models.newsletter import (
@@ -554,7 +554,7 @@ async def send_campaign(
     try:
         from app.workers.newsletter_tasks import send_newsletter_campaign
 
-        send_newsletter_campaign.delay(campaign_id)
+        send_newsletter_campaign.delay(campaign_id, current_user.tenant_id)
     except (ImportError, ConnectionError, TimeoutError, OSError) as exc:
         logger.warning(f"Failed to dispatch newsletter campaign {campaign_id}: {exc}")
         # Worker may not be running in dev; campaign status is already set
@@ -728,7 +728,10 @@ async def campaign_analytics(
 # SUBSCRIBER ENDPOINTS (newsletter-specific)
 # ===================================================================
 @router.get(
-    "/subscribers", response_model=list[SubscriberResponse], tags=["Newsletter"]
+    "/subscribers",
+    response_model=list[SubscriberResponse],
+    tags=["Newsletter"],
+    dependencies=[Depends(require_superadmin())],
 )
 async def list_subscribers(
     current_user: CurrentUserDep,
@@ -762,7 +765,10 @@ async def list_subscribers(
 
 
 @router.get(
-    "/subscribers/stats", response_model=SubscriberStatsResponse, tags=["Newsletter"]
+    "/subscribers/stats",
+    response_model=SubscriberStatsResponse,
+    tags=["Newsletter"],
+    dependencies=[Depends(require_superadmin())],
 )
 async def subscriber_stats(
     current_user: CurrentUserDep,
@@ -784,7 +790,11 @@ async def subscriber_stats(
     )
 
 
-@router.put("/subscribers/{subscriber_id}/unsubscribe", tags=["Newsletter"])
+@router.put(
+    "/subscribers/{subscriber_id}/unsubscribe",
+    tags=["Newsletter"],
+    dependencies=[Depends(require_superadmin())],
+)
 async def manual_unsubscribe(
     subscriber_id: int,
     current_user: CurrentUserDep,
@@ -804,7 +814,11 @@ async def manual_unsubscribe(
     return {"success": True, "message": "Subscriber unsubscribed"}
 
 
-@router.put("/subscribers/{subscriber_id}/resubscribe", tags=["Newsletter"])
+@router.put(
+    "/subscribers/{subscriber_id}/resubscribe",
+    tags=["Newsletter"],
+    dependencies=[Depends(require_superadmin())],
+)
 async def resubscribe(
     subscriber_id: int,
     current_user: CurrentUserDep,

--- a/backend/app/auth/deps.py
+++ b/backend/app/auth/deps.py
@@ -245,6 +245,30 @@ def require_superadmin():
     return require_role(UserRole.SUPERADMIN)
 
 
+def require_tenant_id(user: CurrentUser) -> int:
+    """
+    Return the authenticated user's tenant_id, failing closed.
+
+    Use this instead of ``getattr(user, "tenant_id", None) or <default>``:
+    a missing tenant context must raise 401, never silently resolve to a
+    default tenant (which would leak that tenant's data across accounts).
+    """
+    tenant_id = getattr(user, "tenant_id", None)
+    if not tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Tenant context required",
+        )
+    return tenant_id
+
+
+async def get_tenant_id(
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> int:
+    """FastAPI dependency: the authenticated user's tenant_id, or 401."""
+    return require_tenant_id(current_user)
+
+
 # =============================================================================
 # CMS Auth Dependencies
 # =============================================================================
@@ -472,6 +496,7 @@ CurrentUserDep = Annotated[CurrentUser, Depends(get_current_user)]
 ActiveUserDep = Annotated[CurrentUser, Depends(get_current_active_user)]
 VerifiedUserDep = Annotated[CurrentUser, Depends(get_current_verified_user)]
 OptionalUserDep = Annotated[Optional[CurrentUser], Depends(get_optional_user)]
+TenantIdDep = Annotated[int, Depends(get_tenant_id)]
 AccessibleClientIdsDep = Annotated[
     Optional[list[int]], Depends(get_accessible_client_ids)
 ]

--- a/backend/app/workers/newsletter_tasks.py
+++ b/backend/app/workers/newsletter_tasks.py
@@ -106,7 +106,9 @@ def _add_unsubscribe_footer(
     retry_backoff_max=600,
     max_retries=3,
 )
-def send_newsletter_campaign(self, campaign_id: int) -> dict:
+def send_newsletter_campaign(
+    self, campaign_id: int, tenant_id: int | None = None
+) -> dict:
     """
     Send a newsletter campaign to all matching subscribers.
 
@@ -117,6 +119,10 @@ def send_newsletter_campaign(self, campaign_id: int) -> dict:
     4. Updates campaign stats on completion
 
     Idempotent via status checks — safe to retry.
+
+    When ``tenant_id`` is provided, the campaign load is scoped to that
+    tenant (defense-in-depth against a forced/guessed campaign_id reaching
+    another tenant's campaign).
     """
     from app.base_models import LandingPageSubscriber
     from app.core.config import settings
@@ -134,8 +140,11 @@ def send_newsletter_campaign(self, campaign_id: int) -> dict:
     api_base_url = settings.frontend_url.rstrip("/")
 
     try:
-        # Load campaign
-        campaign = db.query(NewsletterCampaign).filter_by(id=campaign_id).first()
+        # Load campaign (tenant-scoped when tenant_id supplied)
+        campaign_query = db.query(NewsletterCampaign).filter_by(id=campaign_id)
+        if tenant_id is not None:
+            campaign_query = campaign_query.filter_by(tenant_id=tenant_id)
+        campaign = campaign_query.first()
         if not campaign:
             logger.error(f"Campaign {campaign_id} not found")
             return {"error": "Campaign not found"}

--- a/backend/tests/unit/test_tenant_context_dep.py
+++ b/backend/tests/unit/test_tenant_context_dep.py
@@ -1,0 +1,42 @@
+# =============================================================================
+# Stratum AI - Tenant Context Dependency Tests
+# =============================================================================
+"""
+Regression tests for the shared tenant-context resolver (P0-2).
+
+`require_tenant_id` replaces the unsafe `getattr(user, "tenant_id", None) or 1`
+pattern that silently leaked tenant 1's data when a user carried no tenant
+context. It must fail closed (HTTP 401), never default.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.deps import require_tenant_id
+
+
+class _User:
+    """Minimal stand-in for CurrentUser with a settable tenant_id."""
+
+    def __init__(self, tenant_id):
+        self.tenant_id = tenant_id
+
+
+def test_returns_tenant_id_when_present():
+    assert require_tenant_id(_User(7)) == 7
+
+
+@pytest.mark.parametrize("missing", [None, 0])
+def test_fails_closed_on_missing_tenant(missing):
+    """A null/zero tenant must raise 401 — not resolve to a default tenant."""
+    with pytest.raises(HTTPException) as exc_info:
+        require_tenant_id(_User(missing))
+    assert exc_info.value.status_code == 401
+    assert "Tenant context required" in exc_info.value.detail
+
+
+def test_fails_closed_when_attribute_absent():
+    """An object with no tenant_id attribute also fails closed."""
+    with pytest.raises(HTTPException) as exc_info:
+        require_tenant_id(object())
+    assert exc_info.value.status_code == 401


### PR DESCRIPTION
## PR-A · Close P0-2 cross-tenant fallback (shared `TenantContextDep`)

First remediation PR from the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap. The 2026-05 audit's **P0-2** was only partially closed by #293 — the exact `tenant_id = getattr(user, "tenant_id", None) or 1` fallback it removed from three endpoints **survived in `dashboard.py` (10 endpoints)** and adjacent surfaces, silently serving **tenant 1's** data to any user with no tenant context.

### Changes
- **`deps.py`** — add `require_tenant_id(user)` (fail-closed, raises `401 "Tenant context required"`), plus a `get_tenant_id` FastAPI dependency and `TenantIdDep` alias. One shared resolver to replace ad-hoc `or 1` defaults.
- **`dashboard.py`** — replace all **10** `… or 1` fallbacks (`:1903,2180,2302,2480,2603,2700,2809,2955,3058,3242`) with `require_tenant_id(user)`.
- **`advanced_analytics.py`** — gate the raw `/sql` passthrough behind **superadmin**. It previously had *no auth dependency* (trusted middleware state) and injected the tenant filter only for `campaigns`/`campaign_metrics`, leaving every other tenant-scoped table readable cross-tenant.
- **`newsletter.py`** — gate the 4 platform-global subscriber endpoints (list / stats / unsubscribe / resubscribe) behind **superadmin** (the `LandingPageSubscriber` table has no `tenant_id`); pass `tenant_id` into the send dispatch.
- **`newsletter_tasks.py`** — scope `send_newsletter_campaign`'s campaign load by `tenant_id` when provided (defense-in-depth; the API send path was already tenant-scoped).

### Deliberately not changed
`cms.py:3265` `tenant_id=1` is the intentional **"Global CMS tenant"** namespace, gated behind the CMS `manage_users` permission — it's a global content system, not a cross-tenant data leak. Left as-is to avoid a regression (documented).

### Verification (CI-pinned tools)
- `tests/unit/test_tenant_context_dep.py` — asserts fail-closed (`401`) on null / zero / absent tenant. **4 passed.**
- `ruff 0.15.12` ✅ · `black 26.3.1` ✅ · `isort 8.0.1` ✅ · `mypy 1.20.2` → **0 errors**.

### Scope note
This closes **P0-2** as a class. Remaining roadmap items (P0-1 MFA, P0-3 audit key, P0-4 API keys, P0-5 feature gating, P0-6 secrets; P1s) follow in separate PRs per the plan.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_