### PR TITLE
fix(audit): restore audit-log pipeline — unify queue key + field names (P0-3)

### DIFF
--- a/backend/app/core/constants.py
+++ b/backend/app/core/constants.py
@@ -1,0 +1,15 @@
+# =============================================================================
+# Stratum AI - Shared Constants
+# =============================================================================
+"""
+Cross-cutting constants shared between producers and consumers.
+
+Keeping queue keys (and similar string contracts) in one place prevents the
+producer/consumer drift that silently broke the audit-log pipeline, where the
+middleware pushed to ``audit_log_queue`` while the worker drained
+``audit:log:queue``.
+"""
+
+# Redis list key bridging the audit middleware (producer) and the
+# ``process_audit_log_queue`` Celery task (consumer). Both MUST use this.
+AUDIT_LOG_QUEUE_KEY = "audit:log:queue"

--- a/backend/app/middleware/audit.py
+++ b/backend/app/middleware/audit.py
@@ -14,6 +14,7 @@ from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
+from app.core.constants import AUDIT_LOG_QUEUE_KEY
 from app.core.logging import get_logger
 from app.models import AuditAction
 
@@ -114,7 +115,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 "action": action.value,
                 "resource_type": resource_type,
                 "resource_id": resource_id,
-                "new_value": self._sanitize_for_audit(request_body),
+                "new_values": self._sanitize_for_audit(request_body),
                 "ip_address": ip_address,
                 "user_agent": user_agent,
                 "request_id": request_id,
@@ -255,7 +256,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
 
             client = redis.from_url(settings.redis_url)
             try:
-                await client.lpush("audit_log_queue", json.dumps(audit_entry))  # type: ignore[misc]
+                await client.lpush(AUDIT_LOG_QUEUE_KEY, json.dumps(audit_entry))  # type: ignore[misc]
             finally:
                 await client.close()
         except (ConnectionError, TimeoutError, OSError) as e:

--- a/backend/app/workers/tasks/audit.py
+++ b/backend/app/workers/tasks/audit.py
@@ -12,6 +12,7 @@ from celery import shared_task
 from celery.utils.log import get_task_logger
 
 from app.core.config import settings
+from app.core.constants import AUDIT_LOG_QUEUE_KEY
 from app.db.session import SyncSessionLocal
 from app.models import AuditAction, AuditLog
 
@@ -30,7 +31,7 @@ def process_audit_log_queue():
         import redis
 
         redis_client = redis.from_url(settings.redis_url)
-        queue_key = "audit:log:queue"
+        queue_key = AUDIT_LOG_QUEUE_KEY
 
         # Get batch of entries
         batch_size = 100
@@ -60,8 +61,8 @@ def process_audit_log_queue():
                     ip_address=entry.get("ip_address"),
                     user_agent=entry.get("user_agent"),
                     created_at=(
-                        datetime.fromisoformat(entry.get("timestamp"))
-                        if entry.get("timestamp")
+                        datetime.fromisoformat(entry.get("created_at"))
+                        if entry.get("created_at")
                         else datetime.now(UTC)
                     ),
                 )

--- a/backend/tests/unit/test_audit_queue_key.py
+++ b/backend/tests/unit/test_audit_queue_key.py
@@ -1,0 +1,38 @@
+# =============================================================================
+# Stratum AI - Audit Queue Key Contract Tests
+# =============================================================================
+"""
+Regression tests for the audit-log pipeline (P0-3).
+
+The middleware (producer) and the ``process_audit_log_queue`` worker
+(consumer) previously hardcoded *different* Redis keys
+(``audit_log_queue`` vs ``audit:log:queue``), so every audited event was
+silently dropped. Both must now reference the single shared constant.
+"""
+
+from app.core.constants import AUDIT_LOG_QUEUE_KEY
+
+
+def test_constant_is_non_empty_string():
+    assert isinstance(AUDIT_LOG_QUEUE_KEY, str) and AUDIT_LOG_QUEUE_KEY
+
+
+def test_producer_and_consumer_share_the_same_key():
+    """Middleware and worker must drain the exact key the middleware fills."""
+    from app.middleware import audit as producer
+    from app.workers.tasks import audit as consumer
+
+    assert producer.AUDIT_LOG_QUEUE_KEY == AUDIT_LOG_QUEUE_KEY
+    assert consumer.AUDIT_LOG_QUEUE_KEY == AUDIT_LOG_QUEUE_KEY
+
+
+def test_no_legacy_hardcoded_key_remains():
+    """The old mismatched literal must not survive in either module's source."""
+    import inspect
+
+    from app.middleware import audit as producer
+    from app.workers.tasks import audit as consumer
+
+    for mod in (producer, consumer):
+        src = inspect.getsource(mod)
+        assert '"audit_log_queue"' not in src, f"legacy key in {mod.__name__}"


### PR DESCRIPTION
## PR-C · Restore the audit-log pipeline (P0-3)

Second remediation PR from the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap.

The audit middleware (producer) pushed entries to Redis key `audit_log_queue` while the `process_audit_log_queue` worker (consumer) drained `audit:log:queue` — **the keys never matched, so every audited mutation was silently dropped.** While fixing it I also found two **field-name mismatches** that would have persisted malformed rows even after a key fix.

### Changes
- **`app/core/constants.py`** (new) — single `AUDIT_LOG_QUEUE_KEY = "audit:log:queue"`, imported by both producer and consumer so they can never drift again.
- **`middleware/audit.py`** — use the shared key; emit `new_values` (was the singular `new_value`, which the worker never read → request body was lost).
- **`workers/tasks/audit.py`** — use the shared key; read `created_at` (was `timestamp`, which the producer never emitted → every row defaulted to `now()`).

### Verification
- `tests/unit/test_audit_queue_key.py` — asserts producer & consumer share the constant and the legacy `"audit_log_queue"` literal is gone from both. **3 passed.**
- `ruff` ✅ · `black` ✅ · `isort` ✅ · `mypy` → **0 errors**.

### Follow-up (noted, not in this PR)
Tamper-evident hash-chaining of `AuditLog` (the prior audit's "no tamper-evidence" sub-point) needs a model migration — deferred so this PR can ship the dropped-pipeline fix immediately.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_