### PR TITLE
feat(auth): wire inbound API-key authentication (P0-4)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -56,6 +56,7 @@ from app.api.v1.endpoints import (  # Previously unregistered endpoints; Gap end
     payments,
     predictions,
     profit,
+    programmatic,
     push_notifications,
     qa_fixes,
     reporting,
@@ -370,6 +371,13 @@ api_router.include_router(
 api_router.include_router(
     api_keys.router,
     tags=["API Keys"],
+)
+
+# Programmatic API (authenticated by X-API-Key, not JWT)
+# Note: programmatic.router already has prefix="/programmatic"
+api_router.include_router(
+    programmatic.router,
+    tags=["Programmatic API"],
 )
 
 # CDP (Customer Data Platform)

--- a/backend/app/api/v1/endpoints/programmatic.py
+++ b/backend/app/api/v1/endpoints/programmatic.py
@@ -1,0 +1,43 @@
+# =============================================================================
+# Stratum AI - Programmatic API (API-key authenticated)
+# =============================================================================
+"""
+Endpoints authenticated by an inbound API key (``X-API-Key`` header) rather
+than a user JWT. This is the surface third-party/server-side integrations use.
+
+``GET /programmatic/whoami`` is the canonical "is my key valid?" check and the
+first endpoint that actually authenticates an API key (closing audit P0-4).
+Additional programmatic endpoints can adopt ``APIKeyPrincipalDep`` /
+``require_api_key_scope(...)`` as the product surface grows.
+"""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.auth.api_key import APIKeyPrincipalDep
+from app.schemas.response import APIResponse
+
+router = APIRouter(prefix="/programmatic", tags=["Programmatic API"])
+
+
+class APIKeyIdentity(BaseModel):
+    """Identity resolved from a valid API key."""
+
+    key_id: int
+    tenant_id: int
+    user_id: int
+    scopes: list[str]
+
+
+@router.get("/whoami", response_model=APIResponse[APIKeyIdentity])
+async def whoami(principal: APIKeyPrincipalDep) -> APIResponse[APIKeyIdentity]:
+    """Return the identity behind the presented ``X-API-Key``."""
+    return APIResponse(
+        success=True,
+        data=APIKeyIdentity(
+            key_id=principal.id,
+            tenant_id=principal.tenant_id,
+            user_id=principal.user_id,
+            scopes=principal.scopes,
+        ),
+    )

--- a/backend/app/auth/api_key.py
+++ b/backend/app/auth/api_key.py
@@ -1,0 +1,121 @@
+# =============================================================================
+# Stratum AI - API Key Authentication
+# =============================================================================
+"""
+Inbound API-key authentication.
+
+The platform mints API keys (CRUD in ``endpoints/api_keys.py``) but, prior to
+this module, nothing ever *validated* an inbound key — `verify_api_key` had no
+production callers, so keys authenticated nothing (audit P0-4).
+
+`get_api_key_principal` is the missing validator: it reads the ``X-API-Key``
+header, looks the SHA-256 hash up against active, non-expired keys, records
+``last_used_at``, and populates tenant context for downstream middleware.
+Apply it (or ``require_api_key_scope``) to any programmatic endpoint.
+"""
+
+from datetime import datetime, timezone
+from typing import Annotated, Awaitable, Callable, Optional
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import APIKeyHeader
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import get_logger
+from app.core.security import hash_api_key
+from app.db.session import get_async_session
+from app.models import APIKey
+
+logger = get_logger(__name__)
+
+# Declared as a security scheme so it surfaces in the OpenAPI docs.
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+class APIKeyPrincipal:
+    """The authenticated identity behind a valid API key."""
+
+    def __init__(self, api_key: APIKey):
+        self.api_key = api_key
+        self.id = api_key.id
+        self.tenant_id = api_key.tenant_id
+        self.user_id = api_key.user_id
+        self.scopes = list(api_key.scopes or [])
+
+
+async def get_api_key_principal(
+    request: Request,
+    presented_key: Annotated[Optional[str], Depends(api_key_header)],
+    db: AsyncSession = Depends(get_async_session),
+) -> APIKeyPrincipal:
+    """
+    Resolve the ``X-API-Key`` header to an authenticated principal.
+
+    Raises 401 when the key is missing, unknown, inactive, or expired.
+    """
+    invalid = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or missing API key",
+        headers={"WWW-Authenticate": "ApiKey"},
+    )
+    if not presented_key:
+        raise invalid
+
+    key_hash = hash_api_key(presented_key)
+    result = await db.execute(select(APIKey).where(APIKey.key_hash == key_hash))
+    record = result.scalar_one_or_none()
+
+    if record is None or not record.is_active:
+        raise invalid
+
+    if record.expires_at is not None:
+        expires_at = record.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < datetime.now(timezone.utc):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="API key has expired",
+                headers={"WWW-Authenticate": "ApiKey"},
+            )
+
+    # Best-effort usage stamp — never fail auth on a write hiccup.
+    try:
+        record.last_used_at = datetime.now(timezone.utc)
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001 - usage stamping must not block auth
+        await db.rollback()
+        logger.warning("api_key_last_used_update_failed", error=str(exc))
+
+    # Populate tenant context for tenant middleware / audit logging.
+    request.state.tenant_id = record.tenant_id
+    request.state.user_id = record.user_id
+
+    return APIKeyPrincipal(record)
+
+
+def require_api_key_scope(
+    *required_scopes: str,
+) -> Callable[..., Awaitable["APIKeyPrincipal"]]:
+    """
+    Dependency factory enforcing that the API key carries the given scope(s).
+
+    An ``admin`` scope satisfies any requirement.
+    """
+
+    async def scope_checker(
+        principal: Annotated[APIKeyPrincipal, Depends(get_api_key_principal)],
+    ) -> APIKeyPrincipal:
+        held = set(principal.scopes)
+        if "admin" not in held and not set(required_scopes).issubset(held):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"API key missing required scope(s): {', '.join(required_scopes)}",
+            )
+        return principal
+
+    return scope_checker
+
+
+APIKeyPrincipalDep = Annotated[APIKeyPrincipal, Depends(get_api_key_principal)]

--- a/backend/tests/unit/test_api_key_auth.py
+++ b/backend/tests/unit/test_api_key_auth.py
@@ -1,0 +1,127 @@
+# =============================================================================
+# Stratum AI - API Key Authentication Tests
+# =============================================================================
+"""
+Tests for inbound API-key authentication (P0-4).
+
+Before this, `verify_api_key` had no production callers — a presented key
+authenticated nothing. `get_api_key_principal` must now resolve a valid key
+to a principal and reject missing / unknown / inactive / expired keys.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.api_key import (
+    APIKeyPrincipal,
+    get_api_key_principal,
+    require_api_key_scope,
+)
+
+
+class _FakeResult:
+    def __init__(self, record):
+        self._record = record
+
+    def scalar_one_or_none(self):
+        return self._record
+
+
+class _FakeDB:
+    """Minimal async session stub returning a preset APIKey record."""
+
+    def __init__(self, record):
+        self._record = record
+        self.committed = False
+
+    async def execute(self, _query):
+        return _FakeResult(self._record)
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        pass
+
+
+def _key(**overrides):
+    base = dict(
+        id=11,
+        tenant_id=7,
+        user_id=3,
+        scopes=["read"],
+        is_active=True,
+        expires_at=None,
+        key_hash="deadbeef",
+        last_used_at=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _request():
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+async def test_valid_key_resolves_principal_and_sets_context():
+    record = _key()
+    db = _FakeDB(record)
+    req = _request()
+
+    principal = await get_api_key_principal(req, "strat_live_whatever", db)
+
+    assert isinstance(principal, APIKeyPrincipal)
+    assert principal.tenant_id == 7
+    assert principal.user_id == 3
+    assert principal.scopes == ["read"]
+    # tenant context populated for downstream middleware
+    assert req.state.tenant_id == 7
+    assert req.state.user_id == 3
+    # usage stamped
+    assert record.last_used_at is not None
+    assert db.committed is True
+
+
+async def test_missing_key_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_principal(_request(), None, _FakeDB(_key()))
+    assert exc.value.status_code == 401
+
+
+async def test_unknown_key_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_principal(_request(), "nope", _FakeDB(None))
+    assert exc.value.status_code == 401
+
+
+async def test_inactive_key_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_principal(_request(), "k", _FakeDB(_key(is_active=False)))
+    assert exc.value.status_code == 401
+
+
+async def test_expired_key_rejected():
+    expired = _key(expires_at=datetime.now(timezone.utc) - timedelta(days=1))
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_principal(_request(), "k", _FakeDB(expired))
+    assert exc.value.status_code == 401
+    assert "expired" in exc.value.detail.lower()
+
+
+async def test_scope_enforced():
+    record = _key(scopes=["read"])
+    checker = require_api_key_scope("write")
+    principal = APIKeyPrincipal(record)
+    with pytest.raises(HTTPException) as exc:
+        await checker(principal)
+    assert exc.value.status_code == 403
+
+
+async def test_admin_scope_satisfies_any_requirement():
+    record = _key(scopes=["admin"])
+    checker = require_api_key_scope("write", "delete")
+    principal = APIKeyPrincipal(record)
+    assert await checker(principal) is principal


### PR DESCRIPTION
## PR-D · Wire inbound API-key authentication (P0-4)

Third remediation PR from the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap.

API keys were mintable (full CRUD in `api_keys.py`) but **authenticated nothing** — `verify_api_key` had zero production callers and no endpoint ever read an inbound key.

### Changes
- **`app/auth/api_key.py`** (new) — `get_api_key_principal` dependency: reads the `X-API-Key` header (FastAPI `APIKeyHeader`, so it shows in OpenAPI), resolves the SHA-256 hash against **active, non-expired** `APIKey` rows, stamps `last_used_at` (best-effort), and populates tenant/user request state for the tenant middleware + audit log. Plus `require_api_key_scope(...)` (with `admin` override) and an `APIKeyPrincipalDep` alias.
- **`app/api/v1/endpoints/programmatic.py`** (new) — a `/programmatic` router with `GET /whoami`, the first endpoint that authenticates via an API key (a key-validity check for integrations). Deliberately **not** on the `/api-keys` router, which is JWT-superadmin gated.
- Mounted the router in `app/api/v1/__init__.py`.

### Verification
- `tests/unit/test_api_key_auth.py` (**7 passed**): valid key → principal + tenant context + usage stamp; missing / unknown / inactive / expired → `401`; scope enforcement → `403` with `admin` override.
- `ruff` ✅ · `black` ✅ · `isort` ✅ · `mypy` → **0 errors** (whole `app`).

### Scope note
This closes the P0-4 *mechanism* gap — keys now authenticate a real endpoint and the dependency is ready to apply anywhere. **Which** business endpoints (CAPI ingest, server-side tracking, etc.) should accept API keys is a product decision, intentionally left as a follow-up rather than retrofitting auth onto existing JWT endpoints blindly.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_