### PR TITLE
fix(security): encrypt Slack webhook at rest + guard license secret (P0-6)

### DIFF
--- a/backend/app/db/types.py
+++ b/backend/app/db/types.py
@@ -1,0 +1,45 @@
+# =============================================================================
+# Stratum AI - Custom SQLAlchemy Column Types
+# =============================================================================
+"""
+Reusable column types.
+
+`EncryptedString` transparently encrypts a text column at rest with Fernet,
+using the same `encrypt_pii`/`decrypt_pii` helpers the app uses for PII.
+"""
+
+from typing import Optional
+
+from sqlalchemy import String
+from sqlalchemy.types import TypeDecorator
+
+from app.core.security import decrypt_pii, encrypt_pii
+
+
+class EncryptedString(TypeDecorator):
+    """
+    A ``String`` column transparently encrypted at rest with Fernet.
+
+    Encrypts on write, decrypts on read. Rows written before encryption was
+    introduced are returned as-is (they fail to decrypt) and get re-encrypted
+    on their next write — so **no data migration is required** and the
+    underlying column stays ``VARCHAR``.
+    """
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value: Optional[str], dialect) -> Optional[str]:
+        if value is None:
+            return None
+        return encrypt_pii(value)
+
+    def process_result_value(self, value: Optional[str], dialect) -> Optional[str]:
+        if value is None:
+            return None
+        try:
+            return decrypt_pii(value)
+        except ValueError:
+            # Legacy row stored as plaintext before encryption was added.
+            # Return it as-is; it becomes ciphertext on the next write.
+            return value

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -25,6 +25,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db.base_class import Base, StrEnumType, TenantMixin, TimestampMixin
+from app.db.types import EncryptedString
 
 # =============================================================================
 # Enums
@@ -326,8 +327,8 @@ class SlackIntegration(Base, TimestampMixin, TenantMixin):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    # Webhook URL (encrypted)
-    webhook_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    # Webhook URL (encrypted at rest via EncryptedString)
+    webhook_url: Mapped[str] = mapped_column(EncryptedString(2048), nullable=False)
 
     # Channel configuration
     channel_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)

--- a/backend/app/services/tenant/licensing.py
+++ b/backend/app/services/tenant/licensing.py
@@ -29,6 +29,28 @@ from app.core.tiers import SubscriptionTier
 
 logger = get_logger(__name__)
 
+# Dev-only default — must never be used to verify licenses in prod/staging.
+_DEFAULT_DEV_LICENSE_SECRET = "dev-secret-change-me"
+
+
+def _license_signing_secret() -> str:
+    """
+    Resolve the license HMAC signing secret, failing closed in non-dev envs.
+
+    In production/staging, ``LICENSE_SIGNING_SECRET`` must be set to a
+    non-default value; otherwise license verification would trust the public
+    dev secret. In development the dev default is allowed.
+    """
+    secret = os.getenv("LICENSE_SIGNING_SECRET", "")
+    if settings.app_env in ("production", "staging"):
+        if not secret or secret == _DEFAULT_DEV_LICENSE_SECRET:
+            raise RuntimeError(
+                "LICENSE_SIGNING_SECRET must be set to a non-default value in "
+                f"{settings.app_env}"
+            )
+        return secret
+    return secret or _DEFAULT_DEV_LICENSE_SECRET
+
 
 class LicenseStatus(str, Enum):
     """License validation status."""
@@ -262,7 +284,7 @@ class LicenseValidationService:
         """Verify HMAC-signed license data."""
         # Simple HMAC verification for development
         # In production, use RSA/EC signatures
-        secret = os.getenv("LICENSE_SIGNING_SECRET", "dev-secret-change-me")
+        secret = _license_signing_secret()
 
         parts = encoded_data.rsplit(".", 1)
         if len(parts) != 2:

--- a/backend/tests/unit/test_secrets_at_rest.py
+++ b/backend/tests/unit/test_secrets_at_rest.py
@@ -1,0 +1,72 @@
+# =============================================================================
+# Stratum AI - Secrets-at-Rest Tests
+# =============================================================================
+"""
+Tests for P0-6:
+- Slack webhook URL is encrypted at rest (EncryptedString).
+- License HMAC signing secret fails closed in production/staging.
+"""
+
+import pytest
+
+from app.db.types import EncryptedString
+from app.services.tenant import licensing
+
+
+# ---------------------------------------------------------------------------
+# EncryptedString
+# ---------------------------------------------------------------------------
+def test_encrypted_string_round_trips():
+    col = EncryptedString()
+    plaintext = "https://hooks.slack.com/services/T000/B000/XXXXXXXX"
+
+    stored = col.process_bind_param(plaintext, None)
+    assert stored is not None
+    assert stored != plaintext  # actually encrypted at rest
+
+    loaded = col.process_result_value(stored, None)
+    assert loaded == plaintext
+
+
+def test_encrypted_string_reads_legacy_plaintext():
+    """Rows written before encryption must still read (graceful fallback)."""
+    col = EncryptedString()
+    legacy = "https://hooks.slack.com/legacy-plaintext"
+    assert col.process_result_value(legacy, None) == legacy
+
+
+def test_encrypted_string_handles_none():
+    col = EncryptedString()
+    assert col.process_bind_param(None, None) is None
+    assert col.process_result_value(None, None) is None
+
+
+# ---------------------------------------------------------------------------
+# License signing secret guard
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("env", ["production", "staging"])
+def test_license_secret_required_in_prod(monkeypatch, env):
+    monkeypatch.setattr(licensing.settings, "app_env", env)
+    monkeypatch.delenv("LICENSE_SIGNING_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        licensing._license_signing_secret()
+
+
+@pytest.mark.parametrize("env", ["production", "staging"])
+def test_license_default_rejected_in_prod(monkeypatch, env):
+    monkeypatch.setattr(licensing.settings, "app_env", env)
+    monkeypatch.setenv("LICENSE_SIGNING_SECRET", "dev-secret-change-me")
+    with pytest.raises(RuntimeError):
+        licensing._license_signing_secret()
+
+
+def test_license_secret_used_when_set_in_prod(monkeypatch):
+    monkeypatch.setattr(licensing.settings, "app_env", "production")
+    monkeypatch.setenv("LICENSE_SIGNING_SECRET", "a-real-strong-secret")
+    assert licensing._license_signing_secret() == "a-real-strong-secret"
+
+
+def test_license_dev_default_allowed_in_development(monkeypatch):
+    monkeypatch.setattr(licensing.settings, "app_env", "development")
+    monkeypatch.delenv("LICENSE_SIGNING_SECRET", raising=False)
+    assert licensing._license_signing_secret() == "dev-secret-change-me"


### PR DESCRIPTION
## PR-F · Encrypt secrets at rest (P0-6)

Fourth remediation PR from the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap. Two plaintext-secret findings:

### 1. Slack `webhook_url` stored plaintext
The column was a plain `String(2048)` despite a `# (encrypted)` comment.
- **`app/db/types.py`** (new) — `EncryptedString`, a Fernet-backed `TypeDecorator` (encrypt on write, decrypt on read) reusing the app's `encrypt_pii`/`decrypt_pii`.
- Applied to `SlackIntegration.webhook_url`.
- **No schema migration**: the column stays `VARCHAR`. Since `decrypt_pii` raises on non-ciphertext (it deliberately won't leak ciphertext-as-plaintext), `EncryptedString` catches that for legacy rows and returns them as-is — they re-encrypt on their next write.

### 2. License HMAC secret defaulted to a public dev value
`_verify_hmac_license` fell back to a hardcoded `"dev-secret-change-me"` with no prod guard.
- **`licensing.py`** — new `_license_signing_secret()` fails closed: in **production/staging**, `LICENSE_SIGNING_SECRET` must be set to a non-default value (else `RuntimeError`); development keeps the dev default.

### Verification
- `tests/unit/test_secrets_at_rest.py` (**9 passed**): EncryptedString round-trips / reads legacy plaintext / handles None; license secret required + non-default in prod & staging, used when set, dev default allowed in development.
- `ruff` ✅ · `black` ✅ · `isort` ✅ · `mypy` → **0 errors**.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_