### PR TITLE
fix(auth): enforce MFA at login — backend + frontend (P0-1)

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -39,12 +39,15 @@ from app.models import AuditAction, AuditLog, User
 from app.schemas import (
     APIResponse,
     LoginRequest,
+    LoginResponse,
+    MFALoginRequest,
     RefreshTokenRequest,
     TokenResponse,
     UserCreate,
     UserResponse,
 )
 from app.services.email_service import get_email_service
+from app.services.mfa_service import MFAService
 from app.services.whatsapp_client import (
     WhatsAppAPIError,
     WhatsAppNotConfiguredError,
@@ -561,7 +564,80 @@ async def verify_email_otp(request: VerifyEmailOTPRequest):
         )
 
 
-@router.post("/login", response_model=APIResponse[TokenResponse])
+async def _issue_login_tokens(request: Request, user: User, db: AsyncSession) -> dict:
+    """
+    Issue access/refresh tokens for a fully-authenticated user.
+
+    Shared by password login and the MFA second-factor exchange. Updates
+    last-login, writes the LOGIN audit event, and returns the response data
+    (including the multi-account tenant list).
+    """
+    user.last_login_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    access_token = create_access_token(
+        subject=user.id,
+        additional_claims={
+            "tenant_id": user.tenant_id,
+            "role": user.role.value,
+            "cms_role": user.cms_role,
+            # NOTE: email intentionally excluded from JWT to prevent PII leakage
+        },
+    )
+    refresh_token = create_refresh_token(subject=user.id)
+
+    audit_log = AuditLog(
+        tenant_id=user.tenant_id,
+        user_id=user.id,
+        action=AuditAction.LOGIN,
+        resource_type="user",
+        resource_id=str(user.id),
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("User-Agent", "")[:500],
+    )
+    db.add(audit_log)
+    await db.commit()
+
+    logger.info("user_logged_in", user_id=user.id, tenant_id=user.tenant_id)
+
+    from app.models import Tenant as TenantModel
+    from app.models import UserTenantMembership
+
+    membership_result = await db.execute(
+        select(UserTenantMembership, TenantModel)
+        .join(TenantModel, UserTenantMembership.tenant_id == TenantModel.id)
+        .where(
+            UserTenantMembership.user_id == user.id,
+            UserTenantMembership.is_active == True,
+            TenantModel.is_deleted == False,
+        )
+        .order_by(UserTenantMembership.is_default.desc(), TenantModel.name)
+        .limit(1000)
+    )
+    membership_rows = membership_result.all()
+    available_tenants = [
+        {
+            "tenant_id": t.id,
+            "tenant_name": t.name,
+            "tenant_slug": t.slug,
+            "tenant_plan": t.plan,
+            "role": m.role.value if hasattr(m.role, "value") else str(m.role),
+            "is_default": m.is_default,
+            "is_active": m.is_active,
+        }
+        for m, t in membership_rows
+    ]
+
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer",
+        "expires_in": 30 * 60,  # 30 minutes
+        "available_tenants": available_tenants,
+    }
+
+
+@router.post("/login", response_model=APIResponse[LoginResponse])
 async def login(
     request: Request,
     login_data: LoginRequest,
@@ -636,78 +712,79 @@ async def login(
     except (ConnectionError, TimeoutError, OSError) as exc:
         logger.warning("redis_unavailable_clear_login_attempts", error=str(exc))
 
-    # Update last login
-    user.last_login_at = datetime.now(timezone.utc)
-    await db.commit()
-
-    # Create tokens
-    access_token = create_access_token(
-        subject=user.id,
-        additional_claims={
-            "tenant_id": user.tenant_id,
-            "role": user.role.value,
-            "cms_role": user.cms_role,
-            # NOTE: email intentionally excluded from JWT to prevent PII leakage
-            # JWTs are base64-encoded (not encrypted) and visible in request headers
-        },
-    )
-    refresh_token = create_refresh_token(subject=user.id)
-
-    # Log login event
-    audit_log = AuditLog(
-        tenant_id=user.tenant_id,
-        user_id=user.id,
-        action=AuditAction.LOGIN,
-        resource_type="user",
-        resource_id=str(user.id),
-        ip_address=request.client.host if request.client else None,
-        user_agent=request.headers.get("User-Agent", "")[:500],
-    )
-    db.add(audit_log)
-    await db.commit()
-
-    logger.info("user_logged_in", user_id=user.id, tenant_id=user.tenant_id)
-
-    # Fetch available tenants for multi-account switcher
-    from app.models import Tenant as TenantModel
-    from app.models import UserTenantMembership
-
-    membership_result = await db.execute(
-        select(UserTenantMembership, TenantModel)
-        .join(TenantModel, UserTenantMembership.tenant_id == TenantModel.id)
-        .where(
-            UserTenantMembership.user_id == user.id,
-            UserTenantMembership.is_active == True,
-            TenantModel.is_deleted == False,
+    # MFA gate — when the user has a verified second factor, do NOT issue
+    # tokens yet. Return a short-lived challenge token that must be exchanged
+    # (with a TOTP/backup code) at POST /auth/login/mfa.
+    if user.totp_enabled:
+        mfa_challenge = create_access_token(
+            subject=user.id,
+            expires_delta=timedelta(minutes=5),
+            additional_claims={"type": "mfa_challenge"},
         )
-        .order_by(UserTenantMembership.is_default.desc(), TenantModel.name)
-        .limit(1000)
-    )
-    membership_rows = membership_result.all()
-    available_tenants = [
-        {
-            "tenant_id": t.id,
-            "tenant_name": t.name,
-            "tenant_slug": t.slug,
-            "tenant_plan": t.plan,
-            "role": m.role.value if hasattr(m.role, "value") else str(m.role),
-            "is_default": m.is_default,
-            "is_active": m.is_active,
-        }
-        for m, t in membership_rows
-    ]
+        logger.info("login_mfa_required", user_id=user.id)
+        return APIResponse(
+            success=True,
+            data={
+                "mfa_required": True,
+                "mfa_token": mfa_challenge,
+                "token_type": "mfa_challenge",
+            },
+            message="MFA verification required",
+        )
 
-    return APIResponse(
-        success=True,
-        data={
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-            "token_type": "bearer",
-            "expires_in": 30 * 60,  # 30 minutes
-            "available_tenants": available_tenants,
-        },
-        message="Login successful",
+    data = await _issue_login_tokens(request, user, db)
+    return APIResponse(success=True, data=data, message="Login successful")
+
+
+@router.post("/login/mfa", response_model=APIResponse[LoginResponse])
+async def login_mfa(
+    request: Request,
+    body: MFALoginRequest,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Complete MFA login: exchange a challenge token + TOTP/backup code for tokens.
+
+    The challenge token is issued by ``POST /auth/login`` when the user has MFA
+    enabled. Tokens are only issued here, after the second factor is verified.
+    """
+    invalid_session = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or expired MFA session. Please log in again.",
     )
+
+    payload = decode_token(body.mfa_token)
+    if not payload or payload.get("type") != "mfa_challenge":
+        raise invalid_session
+
+    try:
+        user_id = int(payload.get("sub"))
+    except (TypeError, ValueError):
+        raise invalid_session
+
+    result = await db.execute(
+        select(User).where(
+            User.id == user_id,
+            User.is_deleted == False,
+            User.is_active == True,
+        )
+    )
+    user = result.scalar_one_or_none()
+    if not user or not user.totp_enabled:
+        raise invalid_session
+
+    service = MFAService(db)
+    valid, message = await service.verify_code(user_id, body.code)
+    if not valid:
+        logger.warning("login_mfa_failed", user_id=user_id)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=message or "Invalid MFA code",
+        )
+
+    data = await _issue_login_tokens(request, user, db)
+    logger.info("login_mfa_succeeded", user_id=user_id)
+    return APIResponse(success=True, data=data, message="Login successful")
 
 
 @router.post("/register", response_model=APIResponse[UserResponse])

--- a/backend/app/base_schemas.py
+++ b/backend/app/base_schemas.py
@@ -102,6 +102,35 @@ class TokenResponse(BaseSchema):
     expires_in: int
 
 
+class LoginResponse(BaseSchema):
+    """
+    Login response — either issued tokens, or an MFA challenge.
+
+    When the user has MFA enabled, ``mfa_required`` is True and ``mfa_token``
+    carries a short-lived challenge token that must be exchanged (with a TOTP
+    or backup code) at ``POST /auth/login/mfa`` for real tokens.
+    """
+
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    token_type: str = "bearer"
+    expires_in: Optional[int] = None
+    available_tenants: Optional[list] = None
+    mfa_required: bool = False
+    mfa_token: Optional[str] = None
+
+
+class MFALoginRequest(BaseSchema):
+    """Second step of MFA login: exchange a challenge token + code for tokens."""
+
+    mfa_token: str = Field(
+        ..., description="Short-lived MFA challenge token from /login"
+    )
+    code: str = Field(
+        ..., min_length=6, max_length=8, description="TOTP code or backup code"
+    )
+
+
 class LoginRequest(BaseSchema):
     """Login request body."""
 

--- a/backend/tests/unit/test_mfa_at_login.py
+++ b/backend/tests/unit/test_mfa_at_login.py
@@ -1,0 +1,63 @@
+# =============================================================================
+# Stratum AI - MFA-at-Login Tests
+# =============================================================================
+"""
+Tests for the MFA-at-login enforcement (P0-1).
+
+Before this, ``/auth/login`` issued full tokens with no second-factor step.
+Now an MFA-enabled user receives a short-lived ``mfa_challenge`` token that
+must be exchanged at ``/auth/login/mfa``. These tests pin the stateless
+contract the gate relies on.
+"""
+
+from datetime import timedelta
+
+from app.base_schemas import LoginResponse, MFALoginRequest
+from app.core.security import create_access_token, decode_token
+
+
+def test_mfa_challenge_token_is_distinct_from_access_token():
+    """The /login/mfa gate keys off token ``type`` — the two must differ."""
+    challenge = create_access_token(
+        subject=42,
+        expires_delta=timedelta(minutes=5),
+        additional_claims={"type": "mfa_challenge"},
+    )
+    access = create_access_token(subject=42)
+
+    challenge_payload = decode_token(challenge)
+    access_payload = decode_token(access)
+
+    assert challenge_payload is not None and access_payload is not None
+    assert challenge_payload["type"] == "mfa_challenge"
+    assert access_payload["type"] == "access"
+    # An access token must NOT be accepted as a challenge (and vice-versa).
+    assert challenge_payload["type"] != access_payload["type"]
+    assert challenge_payload["sub"] == "42"
+
+
+def test_login_response_supports_mfa_challenge_shape():
+    resp = LoginResponse(mfa_required=True, mfa_token="challenge-token")
+    assert resp.mfa_required is True
+    assert resp.mfa_token == "challenge-token"
+    assert resp.access_token is None  # no tokens until second factor verified
+
+
+def test_login_response_supports_token_shape():
+    resp = LoginResponse(
+        access_token="a", refresh_token="r", expires_in=1800, available_tenants=[]
+    )
+    assert resp.mfa_required is False
+    assert resp.access_token == "a"
+    assert resp.refresh_token == "r"
+
+
+def test_mfa_login_request_validates_code_length():
+    ok = MFALoginRequest(mfa_token="t", code="123456")
+    assert ok.code == "123456"
+
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        MFALoginRequest(mfa_token="t", code="123")  # too short

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -75,7 +75,8 @@ interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
   isDemoSession: boolean;
-  login: (email: string, password: string) => Promise<{ success: boolean; error?: string; lockoutSeconds?: number }>;
+  login: (email: string, password: string) => Promise<{ success: boolean; error?: string; lockoutSeconds?: number; mfaRequired?: boolean; mfaToken?: string }>;
+  loginMfa: (email: string, mfaToken: string, code: string) => Promise<{ success: boolean; error?: string }>;
   demoLogin: (role: 'superadmin' | 'admin' | 'manager' | 'analyst' | 'viewer') => Promise<{ success: boolean; error?: string; lockoutSeconds?: number }>;
   logout: () => void;
   updateUser: (userData: Partial<User>) => void;
@@ -121,10 +122,85 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsLoading(false);
   }, []);
 
+  // Establish the client session from a successful token response. Shared by
+  // password login and the MFA second-factor exchange.
+  const establishSession = async (data: any, email: string): Promise<void> => {
+    if (data.data?.access_token) {
+      sessionStorage.setItem(ACCESS_TOKEN_KEY, data.data.access_token);
+    }
+    if (data.data?.refresh_token) {
+      sessionStorage.setItem(REFRESH_TOKEN_KEY, data.data.refresh_token);
+    }
+
+    if (data.data?.available_tenants && Array.isArray(data.data.available_tenants)) {
+      localStorage.setItem('stratum_available_tenants', JSON.stringify(data.data.available_tenants));
+    }
+
+    const jwtPayload = data.data?.access_token ? decodeJwtPayload(data.data.access_token) : {};
+    const jwtTenantId = jwtPayload.tenant_id as number | undefined;
+
+    const userResponse = await fetch(`${API_BASE}/users/me`, {
+      headers: { Authorization: `Bearer ${data.data.access_token}` },
+    });
+
+    let userInfo: User;
+    if (userResponse.ok) {
+      const userData = await userResponse.json();
+      const tenantId = userData.data.tenant_id ?? jwtTenantId ?? null;
+      const backendRole = userData.data.role || 'analyst';
+      const validRoles = ['superadmin', 'admin', 'manager', 'analyst', 'viewer'];
+      const mappedRole = validRoles.includes(backendRole) ? backendRole : 'analyst';
+      userInfo = {
+        id: String(userData.data.id),
+        email: userData.data.email,
+        name: userData.data.full_name || userData.data.email,
+        role: mappedRole as User['role'],
+        permissions: ['all'],
+        tenant_id: tenantId,
+        user_type: userData.data.user_type || 'agency',
+        client_id: userData.data.client_id ?? null,
+        cms_role: userData.data.cms_role ?? null,
+      };
+    } else {
+      // Fallback if /me fails - create user from token claims
+      userInfo = {
+        id: String(jwtPayload.sub ?? '1'),
+        email: email,
+        name: email.split('@')[0],
+        role: (jwtPayload.role as User['role']) ?? 'admin',
+        permissions: ['all'],
+        tenant_id: jwtTenantId ?? null,
+        user_type: 'agency',
+        cms_role: (jwtPayload.cms_role as string) ?? null,
+      };
+    }
+
+    setUser(userInfo);
+    localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(userInfo));
+
+    const tenantStore = useTenantStore.getState();
+    if (userInfo.tenant_id) {
+      tenantStore.setTenantId(userInfo.tenant_id);
+    }
+    tenantStore.setUser({
+      id: Number(userInfo.id),
+      email: userInfo.email,
+      full_name: userInfo.name,
+      role: userInfo.role,
+      avatar_url: userInfo.avatar ?? null,
+      locale: 'en',
+      timezone: 'UTC',
+      is_active: true,
+      is_verified: true,
+      last_login_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    });
+  };
+
   const login = async (
     email: string,
     password: string
-  ): Promise<{ success: boolean; error?: string; lockoutSeconds?: number }> => {
+  ): Promise<{ success: boolean; error?: string; lockoutSeconds?: number; mfaRequired?: boolean; mfaToken?: string }> => {
     const MAX_RETRIES = 2;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -180,89 +256,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           return { success: false, error: errorMessage };
         }
 
-        // Store tokens in sessionStorage (reduced XSS persistence vs localStorage)
-        if (data.data?.access_token) {
-          sessionStorage.setItem(ACCESS_TOKEN_KEY, data.data.access_token);
-        }
-        if (data.data?.refresh_token) {
-          sessionStorage.setItem(REFRESH_TOKEN_KEY, data.data.refresh_token);
-        }
-
-        // Store available tenants for the switcher
-        if (data.data?.available_tenants && Array.isArray(data.data.available_tenants)) {
-          localStorage.setItem('stratum_available_tenants', JSON.stringify(data.data.available_tenants));
-        }
-
-        // Extract tenant_id from JWT so we can sync it to the tenant store
-        const jwtPayload = data.data?.access_token
-          ? decodeJwtPayload(data.data.access_token)
-          : {};
-        const jwtTenantId = jwtPayload.tenant_id as number | undefined;
-
-        // Fetch user profile
-        const userResponse = await fetch(`${API_BASE}/users/me`, {
-          headers: {
-            Authorization: `Bearer ${data.data.access_token}`,
-          },
-        });
-
-        let userInfo: User;
-
-        if (userResponse.ok) {
-          const userData = await userResponse.json();
-          const tenantId = userData.data.tenant_id ?? jwtTenantId ?? null;
-          // Map backend role to valid frontend role (fallback to 'analyst')
-          const backendRole = userData.data.role || 'analyst';
-          const validRoles = ['superadmin', 'admin', 'manager', 'analyst', 'viewer'];
-          const mappedRole = validRoles.includes(backendRole) ? backendRole : 'analyst';
-          userInfo = {
-            id: String(userData.data.id),
-            email: userData.data.email,
-            name: userData.data.full_name || userData.data.email,
-            role: mappedRole as User['role'],
-            permissions: ['all'],
-            tenant_id: tenantId,
-            user_type: userData.data.user_type || 'agency',
-            client_id: userData.data.client_id ?? null,
-            cms_role: userData.data.cms_role ?? null,
-          };
-        } else {
-          // Fallback if /me fails - create user from token claims
-          userInfo = {
-            id: String(jwtPayload.sub ?? '1'),
-            email: email,
-            name: email.split('@')[0],
-            role: (jwtPayload.role as User['role']) ?? 'admin',
-            permissions: ['all'],
-            tenant_id: jwtTenantId ?? null,
-            user_type: 'agency',
-            cms_role: (jwtPayload.cms_role as string) ?? null,
+        // MFA gate: the backend withholds tokens until the second factor is
+        // verified. Surface that to the UI instead of completing the session.
+        if (data.data?.mfa_required) {
+          return {
+            success: false,
+            mfaRequired: true,
+            mfaToken: data.data.mfa_token as string,
           };
         }
 
-        setUser(userInfo);
-        localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(userInfo));
-
-        // Sync tenant context to Zustand store so other components pick it up
-        const tenantStore = useTenantStore.getState();
-        if (userInfo.tenant_id) {
-          tenantStore.setTenantId(userInfo.tenant_id);
-        }
-        // Also sync user to tenant store for role-based features
-        tenantStore.setUser({
-          id: Number(userInfo.id),
-          email: userInfo.email,
-          full_name: userInfo.name,
-          role: userInfo.role,
-          avatar_url: userInfo.avatar ?? null,
-          locale: 'en',
-          timezone: 'UTC',
-          is_active: true,
-          is_verified: true,
-          last_login_at: new Date().toISOString(),
-          created_at: new Date().toISOString(),
-        });
-
+        await establishSession(data, email);
         return { success: true };
       } catch (error) {
         // On last attempt, return the actual error details
@@ -282,6 +286,52 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     return { success: false, error: 'Login failed. Please try again.' };
+  };
+
+  // Second step of MFA login: exchange the challenge token + TOTP/backup code
+  // for real tokens, then establish the session.
+  const loginMfa = async (
+    email: string,
+    mfaToken: string,
+    code: string
+  ): Promise<{ success: boolean; error?: string }> => {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 15000);
+
+      const response = await fetch(`${API_BASE}/auth/login/mfa`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mfa_token: mfaToken, code }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        let errorMessage = 'Verification failed';
+        if (data.detail) {
+          if (typeof data.detail === 'string') {
+            errorMessage = data.detail;
+          } else if (Array.isArray(data.detail) && data.detail.length > 0) {
+            errorMessage = data.detail[0].msg || data.detail[0].message || 'Invalid code';
+          } else if (typeof data.detail === 'object' && data.detail.msg) {
+            errorMessage = data.detail.msg;
+          }
+        }
+        return { success: false, error: errorMessage };
+      }
+
+      await establishSession(data, email);
+      return { success: true };
+    } catch (error) {
+      const msg =
+        error instanceof DOMException && error.name === 'AbortError'
+          ? 'Connection timed out. Please try again.'
+          : `Connection failed: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      return { success: false, error: msg };
+    }
   };
 
   /** Client-side demo login — creates a mock session without hitting the backend */
@@ -390,11 +440,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isLoading,
       isDemoSession,
       login,
+      loginMfa,
       demoLogin,
       logout,
       updateUser,
     }),
-    [user, isLoading, isDemoSession, login, demoLogin, logout, updateUser]
+    [user, isLoading, isDemoSession, login, loginMfa, demoLogin, logout, updateUser]
   );
 
   return (

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -16,7 +16,7 @@ const MONO_STACK = 'Geist Mono, monospace';
 export default function Login() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { login } = useAuth();
+  const { login, loginMfa } = useAuth();
 
   const formRef = useRef<HTMLFormElement>(null);
   const [email, setEmail] = useState('');
@@ -29,6 +29,10 @@ export default function Login() {
   );
   const [touched, setTouched] = useState<{ email?: boolean; password?: boolean }>({});
   const [lockoutSeconds, setLockoutSeconds] = useState(0);
+  // MFA second-factor step
+  const [mfaRequired, setMfaRequired] = useState(false);
+  const [mfaToken, setMfaToken] = useState('');
+  const [mfaCode, setMfaCode] = useState('');
 
   useEffect(() => {
     if (lockoutSeconds <= 0) return;
@@ -91,7 +95,10 @@ export default function Login() {
 
     try {
       const result = await login(actualEmail, actualPassword);
-      if (result.success) {
+      if (result.mfaRequired && result.mfaToken) {
+        setMfaToken(result.mfaToken);
+        setMfaRequired(true);
+      } else if (result.success) {
         if (rememberMe) {
           localStorage.setItem('stratum_remember_me', 'true');
         } else {
@@ -110,6 +117,43 @@ export default function Login() {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleMfaSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!mfaCode || mfaCode.length < 6) {
+      setError('Enter the 6-digit code from your authenticator app');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await loginMfa(email, mfaToken, mfaCode);
+      if (result.success) {
+        if (rememberMe) {
+          localStorage.setItem('stratum_remember_me', 'true');
+        } else {
+          localStorage.removeItem('stratum_remember_me');
+          sessionStorage.setItem('stratum_session_only', 'true');
+        }
+        navigate(from, { replace: true });
+      } else {
+        setError(result.error || 'Verification failed');
+      }
+    } catch {
+      setError('An unexpected error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const cancelMfa = () => {
+    setMfaRequired(false);
+    setMfaToken('');
+    setMfaCode('');
+    setError('');
   };
 
   return (
@@ -161,6 +205,55 @@ export default function Login() {
               </p>
             </div>
 
+            {mfaRequired ? (
+              <form onSubmit={handleMfaSubmit} className="space-y-5">
+                <div>
+                  <h2 className="text-lg font-medium text-white">Two-factor authentication</h2>
+                  <p className="text-[13px] text-[#9A9A9A] mt-1">
+                    Enter the 6-digit code from your authenticator app, or a backup code.
+                  </p>
+                </div>
+                {error && (
+                  <div className="flex items-start gap-2 p-3 rounded-[12px] text-sm bg-[rgba(239,68,68,0.08)] border border-red-500/30 text-red-300">
+                    <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                    <span>{error}</span>
+                  </div>
+                )}
+                <div>
+                  <label htmlFor="mfa-code" className="block text-[13px] text-[#9A9A9A] mb-1.5">
+                    Verification code
+                  </label>
+                  <input
+                    id="mfa-code"
+                    name="mfa-code"
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    autoFocus
+                    value={mfaCode}
+                    onChange={(e) => setMfaCode(e.target.value.replace(/\s/g, ''))}
+                    maxLength={8}
+                    placeholder="123456"
+                    className="w-full h-12 px-4 rounded-[12px] bg-[#141414] border border-[#262626] text-white text-center tracking-[0.4em] text-lg placeholder:text-[#5A5A5A] focus:border-[#FF5A1F] focus:outline-none transition-colors"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  className="w-full h-12 rounded-full bg-[#FF5A1F] text-white font-medium text-[14px] flex items-center justify-center gap-2 transition-all hover:bg-[#FF6E3A] hover:-translate-y-px disabled:opacity-50 disabled:hover:translate-y-0 disabled:cursor-not-allowed"
+                  style={{ boxShadow: '0 4px 14px rgba(255,90,31,0.3)' }}
+                >
+                  {isLoading ? 'Verifying...' : 'Verify'}
+                </button>
+                <button
+                  type="button"
+                  onClick={cancelMfa}
+                  className="w-full text-[13px] text-[#9A9A9A] hover:text-white transition-colors"
+                >
+                  Back to sign in
+                </button>
+              </form>
+            ) : (
             <form ref={formRef} onSubmit={handleSubmit} className="space-y-5">
               {/* Verification banner */}
               {showVerificationBanner && (
@@ -345,6 +438,7 @@ export default function Login() {
                 )}
               </button>
             </form>
+            )}
 
             {/* Footer */}
             <div className="mt-10 pt-6 border-t border-[#1F1F1F]">


### PR DESCRIPTION
## PR-B · Enforce MFA at login (P0-1) — backend + frontend

Marquee blocker from the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299). `/auth/login` issued full access/refresh tokens **immediately after password verification**, so the entire TOTP subsystem was unreachable and MFA was never enforced. This PR now closes it **end-to-end** (no separate frontend follow-up needed).

### Backend
- **`/auth/login`** — when `user.totp_enabled`, stop issuing tokens; return a short-lived (**5 min**) `mfa_challenge` JWT with `mfa_required: true`.
- **`POST /auth/login/mfa`** (new) — exchanges `{ mfa_token, code }` for real tokens after `MFAService.verify_code` passes (TOTP **or** backup code, honoring the existing failed-attempt lockout). **Stateless** — the signed, expiring challenge token *is* the pending-auth state.
- **`_issue_login_tokens()`** — extracted, shared by both paths (last-login, LOGIN audit event, multi-account tenant list).
- **Schemas** — `LoginResponse` (tokens **or** challenge) + `MFALoginRequest`; `/login` `response_model` switched to `LoginResponse` (also stops `available_tenants` being silently dropped by the old model).

### Frontend
- **`AuthContext`** — `login()` surfaces `{ mfaRequired, mfaToken }`; new `loginMfa(email, mfaToken, code)` posts to `/auth/login/mfa`. Extracted a shared `establishSession()` helper (tokens, `/users/me`, tenant-store sync) used by both paths — **no behavior change for non-MFA users**.
- **`Login.tsx`** — when `mfaRequired`, swaps the password form for a 6-digit code entry (`autocomplete="one-time-code"`, backup codes accepted) with a Verify action and a "Back to sign in" escape.

### Verification
- Backend: `tests/unit/test_mfa_at_login.py` (**4 passed**) — challenge-vs-access token-type discrimination, response-schema shapes, request validation. `ruff`/`black`/`isort` clean, `mypy` 0 errors.
- Frontend: `tsc --noEmit -p tsconfig.build.json` clean. *(eslint/vitest couldn't run in the sandbox due to a pre-existing vite/plugin-react + eslint-plugin-react version conflict, unrelated to this change — frontend CI will run them.)*
- Non-MFA users (`totp_enabled = False`, the default) are unaffected on both ends.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_