### PR TITLE
fix(billing): enforce tier feature gating on premium routers (P0-5)

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -5,7 +5,7 @@
 Main API router that aggregates all endpoint routers.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.api.v1.endpoints import (  # Previously unregistered endpoints; Gap endpoints; SendGrid inbound webhook; Drip campaigns and push notifications
     advanced_analytics,
@@ -75,6 +75,8 @@ from app.api.v1.endpoints import (  # Previously unregistered endpoints; Gap end
     webhooks,
     whatsapp,
 )
+from app.core.feature_gate import FeatureGate
+from app.core.tiers import Feature
 
 api_router = APIRouter()
 
@@ -127,11 +129,12 @@ api_router.include_router(
     tags=["Competitor Intelligence"],
 )
 
-# ML Simulator (Module A)
+# ML Simulator (Module A) — What-If Simulator is an Enterprise feature (P0-5)
 api_router.include_router(
     simulator.router,
     prefix="/simulate",
     tags=["ML Simulator"],
+    dependencies=[Depends(FeatureGate(Feature.WHAT_IF_SIMULATOR))],
 )
 
 # Analytics & Dashboard
@@ -141,11 +144,12 @@ api_router.include_router(
     tags=["Analytics"],
 )
 
-# GDPR Compliance (Module F)
+# GDPR Compliance (Module F) — GDPR tools are an Enterprise feature (P0-5)
 api_router.include_router(
     gdpr.router,
     prefix="/gdpr",
     tags=["GDPR Compliance"],
+    dependencies=[Depends(FeatureGate(Feature.GDPR_TOOLS))],
 )
 
 # WhatsApp Integration (Module G)

--- a/backend/tests/unit/test_feature_gating.py
+++ b/backend/tests/unit/test_feature_gating.py
@@ -1,0 +1,66 @@
+# =============================================================================
+# Stratum AI - Feature Gating Tests
+# =============================================================================
+"""
+Tests for tier-based feature gating (P0-5).
+
+Before this, FeatureGate/TierGate/require_feature were applied to zero
+endpoints — a free tenant could call enterprise features. These tests pin
+the gate behaviour against the real TIER_FEATURES matrix.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import feature_gate as fg
+from app.core.tiers import Feature, SubscriptionTier
+
+
+def _request(tenant_id=5):
+    return SimpleNamespace(state=SimpleNamespace(tenant_id=tenant_id))
+
+
+async def test_starter_blocked_from_enterprise_feature(monkeypatch):
+    async def fake_tier(_tenant_id):
+        return SubscriptionTier.STARTER
+
+    monkeypatch.setattr(fg, "get_tenant_tier", fake_tier)
+    gate = fg.FeatureGate(Feature.WHAT_IF_SIMULATOR, check_subscription=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await gate(_request())
+    assert exc.value.status_code == 403
+
+
+async def test_enterprise_allowed(monkeypatch):
+    async def fake_tier(_tenant_id):
+        return SubscriptionTier.ENTERPRISE
+
+    monkeypatch.setattr(fg, "get_tenant_tier", fake_tier)
+    gate = fg.FeatureGate(Feature.WHAT_IF_SIMULATOR, check_subscription=False)
+
+    # Should not raise for an enterprise tenant.
+    assert await gate(_request()) is None
+
+
+async def test_gdpr_tools_gated_to_enterprise(monkeypatch):
+    async def fake_tier(_tenant_id):
+        return SubscriptionTier.PROFESSIONAL
+
+    monkeypatch.setattr(fg, "get_tenant_tier", fake_tier)
+    gate = fg.FeatureGate(Feature.GDPR_TOOLS, check_subscription=False)
+
+    with pytest.raises(HTTPException) as exc:
+        await gate(_request())
+    assert exc.value.status_code == 403
+
+
+def test_gated_features_are_not_in_starter_tier():
+    """Guard: the features we gate must genuinely be non-Starter."""
+    from app.core.tiers import has_feature
+
+    for feature in (Feature.WHAT_IF_SIMULATOR, Feature.GDPR_TOOLS):
+        assert not has_feature(SubscriptionTier.STARTER, feature)
+        assert has_feature(SubscriptionTier.ENTERPRISE, feature)


### PR DESCRIPTION
## PR-E · Enforce tier feature gating (P0-5)

Final P0 from the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap.

`FeatureGate` / `TierGate` / `require_feature` existed but were applied to **zero** endpoints — a free/expired tenant could call enterprise features, and an expired subscription was never blocked.

### Changes
Wired the existing `FeatureGate` dependency onto two unambiguously **Enterprise-tier** routers as the initial, conservative enforcement set (and the reusable pattern):
- `/simulate` (What-If Simulator) → `FeatureGate(Feature.WHAT_IF_SIMULATOR)`
- `/gdpr` (GDPR tools) → `FeatureGate(Feature.GDPR_TOOLS)`

`FeatureGate` also returns **402** when the tenant's subscription is expired (via `is_access_allowed`), so this closes both the tier-bypass **and** the expired-subscription bypass for these surfaces. Both features are confirmed non-Starter in `TIER_FEATURES`.

### Verification
- `tests/unit/test_feature_gating.py` (**4 passed**): Starter & Professional → `403` on enterprise features; Enterprise allowed; a guard asserts the gated features are genuinely non-Starter in the real `TIER_FEATURES` matrix.
- `ruff` ✅ · `black` ✅ · `isort` ✅ · `mypy` → **0 errors**.

### Scope note
Deliberately conservative: two clearly-Enterprise routers prove the mechanism without risking lockout of mis-tiered beta tenants. **Follow-up:** extend gating across the full `TIER_FEATURES` matrix (predictive churn, custom autopilot rules, CRM writeback, identity graph, …) — a per-endpoint mapping exercise scoped out here.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_