### PR TITLE
style(ci): unblock Backend CI — reformat #294 files under pinned black/isort

### DIFF
--- a/backend/app/api/v1/endpoints/campaign_builder.py
+++ b/backend/app/api/v1/endpoints/campaign_builder.py
@@ -21,6 +21,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.logging import get_logger
 from app.core.security import require_permission
 from app.db.session import get_async_session
 from app.models.campaign_builder import (
@@ -34,7 +35,6 @@ from app.models.campaign_builder import (
     TenantPlatformConnection,
 )
 from app.schemas.response import APIResponse, PaginatedResponse
-from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 router = APIRouter(prefix="/tenant/{tenant_id}", tags=["campaign-builder"])

--- a/backend/app/api/v1/endpoints/trust_layer.py
+++ b/backend/app/api/v1/endpoints/trust_layer.py
@@ -57,7 +57,7 @@ async def get_signal_health(
     if not await can_access_feature(db, tenant_id, "signal_health"):
         raise HTTPException(
             status_code=403,
-            detail="Signal health feature is not enabled for this tenant"
+            detail="Signal health feature is not enabled for this tenant",
         )
 
     service = SignalHealthService(db)

--- a/backend/app/services/offline_conversion_service.py
+++ b/backend/app/services/offline_conversion_service.py
@@ -22,13 +22,13 @@ import csv
 import hashlib
 import io
 import json
+import statistics
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
-import statistics
 
 from app.core.logging import get_logger
 from app.services.capi.pii_hasher import PIIHasher

--- a/backend/app/services/profit/cogs_service.py
+++ b/backend/app/services/profit/cogs_service.py
@@ -11,12 +11,9 @@ Features:
 - Historical COGS tracking
 """
 
-from datetime import date, datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, BinaryIO
-from uuid import UUID
 import csv
 import io
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, BinaryIO, Dict, List, Optional
 from uuid import UUID
 


### PR DESCRIPTION
## Unblock Backend CI — pinned black/isort drift

Backend CI is **red on `main`** at the `black --check` gate — and because the check scans the whole repo, this fails Backend CI on **every open PR** (confirmed: the docs-only #299 fails identically).

### Root cause
`requirements.txt` pins `black==26.5.1` and `isort==8.0.1` (moved forward by a dependabot bump), but four files added by the crash-fix PR (#294) were never reformatted under those versions — the #295 sweep used an older black. So:
- `black 26.5.1` wants a trailing comma in a `trust_layer.py` `HTTPException(...)` call.
- `isort 8.0.1` wants reordered imports in three #294-touched files.

### Fix (formatting only — no logic change)
| File | Tool |
|---|---|
| `api/v1/endpoints/trust_layer.py` | black (trailing comma) |
| `api/v1/endpoints/campaign_builder.py` | isort |
| `services/offline_conversion_service.py` | isort |
| `services/profit/cogs_service.py` | isort |

### Verification (pinned toolchain)
`ruff 0.15.15` ✅ · `black 26.5.1` ✅ · `isort 8.0.1` ✅ · `mypy 1.20.2` → **0 errors** — all clean across the backend.

**Merge this first** — it makes `main`'s Backend CI lint+type gates green, so the other open PRs go green on rebase. (The remaining Backend CI step — DB-backed unit tests — is a separate pre-existing concern needing Postgres/Redis.)

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_