### PR TITLE
feat(kg): shelve Knowledge Graph behind a feature flag (P1-6)

### DIFF
--- a/backend/app/api/v1/endpoints/knowledge_graph.py
+++ b/backend/app/api/v1/endpoints/knowledge_graph.py
@@ -7,11 +7,12 @@ Provides REST API for Knowledge Graph analytics, insights, and problem detection
 from datetime import UTC, datetime
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.base_models import User
+from app.core.config import settings
 from app.services.knowledge_graph import (
     KnowledgeGraphInsightsEngine,
     KnowledgeGraphService,
@@ -20,7 +21,26 @@ from app.services.knowledge_graph import (
 )
 from app.tenancy.deps import get_current_user, get_db
 
-router = APIRouter()
+
+async def require_knowledge_graph_enabled() -> None:
+    """
+    Gate the Knowledge Graph behind a feature flag.
+
+    The KG depends on the Apache AGE Postgres extension, which is not
+    provisioned in the default image. Until it is, the feature is shelved:
+    every route returns 503 instead of failing deep in a Cypher query.
+    """
+    if not settings.feature_knowledge_graph:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "Knowledge Graph is not enabled on this deployment "
+                "(requires the Apache AGE extension)."
+            ),
+        )
+
+
+router = APIRouter(dependencies=[Depends(require_knowledge_graph_enabled)])
 
 
 # =============================================================================

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -361,6 +361,9 @@ class Settings(BaseSettings):
     feature_what_if_simulator: bool = Field(default=True)
     feature_automation_rules: bool = Field(default=True)
     feature_gdpr_compliance: bool = Field(default=True)
+    # Knowledge Graph requires Apache AGE (not provisioned in the default
+    # image); shelved off by default until AGE is available.
+    feature_knowledge_graph: bool = Field(default=False)
 
     @property
     def is_development(self) -> bool:

--- a/backend/tests/unit/test_knowledge_graph_shelved.py
+++ b/backend/tests/unit/test_knowledge_graph_shelved.py
@@ -1,0 +1,34 @@
+# =============================================================================
+# Stratum AI - Knowledge Graph Shelving Tests
+# =============================================================================
+"""
+Tests for shelving the Knowledge Graph behind a feature flag (P1-6).
+
+The KG depends on the Apache AGE Postgres extension, which is not
+provisioned. The router-level gate must return 503 when the flag is off
+(the default) and allow requests through when it is explicitly enabled.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.knowledge_graph import require_knowledge_graph_enabled
+from app.core.config import settings
+
+
+async def test_disabled_by_default_returns_503(monkeypatch):
+    monkeypatch.setattr(settings, "feature_knowledge_graph", False)
+    with pytest.raises(HTTPException) as exc:
+        await require_knowledge_graph_enabled()
+    assert exc.value.status_code == 503
+    assert "AGE" in exc.value.detail
+
+
+async def test_enabled_passes(monkeypatch):
+    monkeypatch.setattr(settings, "feature_knowledge_graph", True)
+    assert await require_knowledge_graph_enabled() is None
+
+
+def test_flag_defaults_off():
+    # Shipped default must be off (KG undeployable without AGE).
+    assert settings.feature_knowledge_graph is False


### PR DESCRIPTION
## PR-K · Shelve Knowledge Graph behind a feature flag (P1-6)

From the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap (you chose *shelve behind a flag*).

The Knowledge Graph depends on the **Apache AGE** Postgres extension, which isn't provisioned in the default image — `CREATE EXTENSION age` exists only in the *inactive* alembic tree. Every KG route therefore failed deep inside a Cypher query at runtime.

### Changes
- **`config.py`** — add `feature_knowledge_graph` (default **False**).
- **`knowledge_graph.py`** — router-level `require_knowledge_graph_enabled` dependency returns **503** with a clear message when the flag is off, so all routes short-circuit *before* touching AGE (no more deep Cypher crashes).

Flip the flag to `True` once an AGE-enabled Postgres + the active-tree migration are in place.

### Verification
- `tests/unit/test_knowledge_graph_shelved.py` — 503 when disabled (default), passes when enabled, default-off guard.
- `ruff 0.15.15` ✅ · `black 26.5.1` ✅ · `isort 8.0.1` ✅ · `mypy 1.20.2` → **0 errors**. *(The unit test runs in CI's full environment; the sandbox lacks the ML deps the `api.v1` package import pulls in — mypy already import-validated the module.)*

> Built with the **pinned** toolchain (26.5.1/0.15.15) per #306, so this branch is lint-clean on its own.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_