### PR TITLE
feat(workers): wire orphaned campaign-builder beat tasks, flag-gated (P1-2)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -361,6 +361,9 @@ class Settings(BaseSettings):
     feature_what_if_simulator: bool = Field(default=True)
     feature_automation_rules: bool = Field(default=True)
     feature_gdpr_compliance: bool = Field(default=True)
+    # Campaign-builder connector beat tasks (ad-account sync, token refresh,
+    # health checks) hit live platform APIs — opt-in, default off (P1-2).
+    enable_campaign_builder_beat: bool = Field(default=False)
 
     @property
     def is_development(self) -> bool:

--- a/backend/app/workers/campaign_builder_tasks.py
+++ b/backend/app/workers/campaign_builder_tasks.py
@@ -450,20 +450,6 @@ def connector_health_check(self, tenant_id: Optional[int] = None):
 # =============================================================================
 # Scheduled Tasks Registration
 # =============================================================================
-# These should be added to celery_app.conf.beat_schedule in celery_app.py:
-#
-# "sync-all-ad-accounts": {
-#     "task": "app.workers.campaign_builder_tasks.sync_all_ad_accounts",
-#     "schedule": crontab(hour=2, minute=0),
-#     "options": {"queue": "sync"},
-# },
-# "refresh-expiring-tokens": {
-#     "task": "app.workers.campaign_builder_tasks.refresh_expiring_tokens",
-#     "schedule": crontab(hour="*/6"),
-#     "options": {"queue": "default"},
-# },
-# "connector-health-check": {
-#     "task": "app.workers.campaign_builder_tasks.connector_health_check",
-#     "schedule": crontab(minute="*/30"),
-#     "options": {"queue": "default"},
-# },
+# These tasks are now registered on celery_app.conf.beat_schedule in
+# celery_app.py, gated behind settings.enable_campaign_builder_beat
+# (default off). This module is included in the Celery app's `include` list.

--- a/backend/app/workers/celery_app.py
+++ b/backend/app/workers/celery_app.py
@@ -16,7 +16,7 @@ celery_app = Celery(
     "stratum_ai",
     broker=settings.celery_broker_url,
     backend=settings.celery_result_backend,
-    include=["app.workers.tasks"],
+    include=["app.workers.tasks", "app.workers.campaign_builder_tasks"],
 )
 
 # Celery configuration
@@ -138,6 +138,36 @@ celery_app.conf.beat_schedule = {
         "options": {"queue": "default"},
     },
 }
+
+
+# ---------------------------------------------------------------------------
+# Opt-in periodic tasks
+# ---------------------------------------------------------------------------
+# The campaign-builder connector tasks exist but were never registered on the
+# beat schedule (orphaned). They sync ad accounts, refresh OAuth tokens, and
+# health-check connectors — all of which hit live platform APIs, so they are
+# gated behind a default-off flag. Set ENABLE_CAMPAIGN_BUILDER_BEAT=true once
+# connectors/credentials are configured.
+if settings.enable_campaign_builder_beat:
+    celery_app.conf.beat_schedule.update(
+        {
+            "sync-all-ad-accounts": {
+                "task": "app.workers.campaign_builder_tasks.sync_all_ad_accounts",
+                "schedule": crontab(hour=2, minute=0),
+                "options": {"queue": "sync"},
+            },
+            "refresh-expiring-tokens": {
+                "task": "app.workers.campaign_builder_tasks.refresh_expiring_tokens",
+                "schedule": crontab(hour="*/6"),
+                "options": {"queue": "default"},
+            },
+            "connector-health-check": {
+                "task": "app.workers.campaign_builder_tasks.connector_health_check",
+                "schedule": crontab(minute="*/30"),
+                "options": {"queue": "default"},
+            },
+        }
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_campaign_builder_beat_wiring.py
+++ b/backend/tests/unit/test_campaign_builder_beat_wiring.py
@@ -1,0 +1,34 @@
+# =============================================================================
+# Stratum AI - Campaign-Builder Beat Wiring Tests
+# =============================================================================
+"""
+Tests for wiring the orphaned campaign-builder connector tasks (P1-2).
+
+The tasks (ad-account sync, token refresh, connector health check) existed
+but were never on the beat schedule, and the module wasn't in the Celery
+`include` list. They hit live platform APIs, so they're gated behind
+``enable_campaign_builder_beat`` (default off).
+"""
+
+from app.core.config import settings
+from app.workers.celery_app import celery_app
+
+_CAMPAIGN_BUILDER_ENTRIES = {
+    "sync-all-ad-accounts",
+    "refresh-expiring-tokens",
+    "connector-health-check",
+}
+
+
+def test_flag_defaults_off():
+    # Live platform calls must not auto-fire without explicit opt-in.
+    assert settings.enable_campaign_builder_beat is False
+
+
+def test_task_module_is_included():
+    assert "app.workers.campaign_builder_tasks" in celery_app.conf.include
+
+
+def test_beat_excludes_campaign_builder_when_flag_off():
+    scheduled = set(celery_app.conf.beat_schedule.keys())
+    assert _CAMPAIGN_BUILDER_ENTRIES.isdisjoint(scheduled)


### PR DESCRIPTION
## PR-H · Wire orphaned campaign-builder beat tasks (P1-2)

From the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap (you chose **flag-gated, default-off**).

The campaign-builder connector tasks (`sync_all_ad_accounts`, `refresh_expiring_tokens`, `connector_health_check`) existed as `@shared_task`s but were **never registered** — the module wasn't in Celery's `include`, and the beat entries sat commented out. So they never ran.

### Changes
- **`config.py`** — add `enable_campaign_builder_beat` (default **False**).
- **`celery_app.py`** — add `app.workers.campaign_builder_tasks` to `include`; register the three beat entries **only when the flag is on**.
- **`campaign_builder_tasks.py`** — replace the stale "should be added" comment.

These tasks hit live platform APIs (ad-account sync, OAuth refresh), so they stay off until an operator sets `ENABLE_CAMPAIGN_BUILDER_BEAT=true` with connectors/credentials configured.

### Scope (honest)
This PR wires only the orphaned tasks that **already exist and are correct**. The other P1-2 items need *new* task logic and are deliberately left as follow-ups:
- **Reporting scheduler** — `process_due_schedules()` is tenant-scoped; needs a cross-tenant driver task.
- **Drip worker** — no worker exists.
- **Profit `DailyProfitMetrics` writer** — needs a new aggregation task.
- **CAPI `delivery_logger`/`dead_letter_queue`** — needs send-path integration.

### Verification
- `tests/unit/test_campaign_builder_beat_wiring.py` (**3 passed**) — flag defaults off, module in `include`, beat entries absent by default.
- `ruff 0.15.15` ✅ · `black 26.5.1` ✅ · `isort 8.0.1` ✅ · `mypy 1.20.2` → **0 errors** (pinned toolchain per #306).

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_