### PR TITLE
feat(stratum): register platform adapters at startup (P1-5)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -212,6 +212,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             detail="ML predictions will be unavailable",
         )
 
+    # Register platform ad-adapters so the stratum action layer can resolve
+    # them by platform (Meta/Google/TikTok/Snapchat). Previously defined but
+    # never called at startup, leaving the registry empty.
+    try:
+        from app.stratum.adapters.registry import register_default_adapters
+
+        register_default_adapters()
+        logger.info("platform_adapters_registered")
+    except (ImportError, RuntimeError, ValueError) as e:
+        logger.warning("platform_adapter_registration_failed", error=str(e))
+
     # Auto-seed superadmin if not exists or update password
     try:
         from scripts.seed_superadmin import create_superadmin

--- a/backend/tests/unit/test_adapter_registry_wiring.py
+++ b/backend/tests/unit/test_adapter_registry_wiring.py
@@ -1,0 +1,39 @@
+# =============================================================================
+# Stratum AI - Adapter Registry Wiring Tests
+# =============================================================================
+"""
+Tests for wiring the platform adapter registry (P1-5).
+
+`register_default_adapters()` was defined but never called at startup, so
+`AdapterRegistry` was always empty and the stratum action layer could not
+resolve any platform adapter. It's now invoked in the app lifespan.
+"""
+
+import pytest
+
+from app.stratum.adapters.base import BaseAdapter
+from app.stratum.adapters.registry import AdapterRegistry, register_default_adapters
+from app.stratum.models import Platform
+
+
+class _DummyAdapter(BaseAdapter):
+    """Bare adapter subclass for exercising the registry mechanism."""
+
+
+def test_register_and_list_mechanism():
+    AdapterRegistry.register(Platform.META, _DummyAdapter)
+    assert AdapterRegistry.list_registered().get("meta") == "_DummyAdapter"
+
+
+def test_register_default_adapters_registers_all_platforms():
+    # The real adapters import platform SDKs (google-ads, facebook-business…)
+    # which may be absent locally; the call is import-guarded at startup, so
+    # skip cleanly here and let CI exercise the full path.
+    try:
+        register_default_adapters()
+    except ImportError:
+        pytest.skip("platform SDKs not installed in this environment")
+
+    registered = AdapterRegistry.list_registered()
+    for platform in ("meta", "google", "tiktok", "snapchat"):
+        assert platform in registered


### PR DESCRIPTION
## PR-J (part) · Register platform adapters at startup (P1-5)

From the [re-audit](https://github.com/Ibrahim-newaeon/Stratum-AI-Final-Updates-Dec-2025/pull/299) roadmap.

`register_default_adapters()` was defined but **never called**, so `AdapterRegistry` stayed empty and the stratum action layer couldn't resolve any platform adapter (Meta/Google/TikTok/Snapchat).

### Change
- **`main.py`** — call `register_default_adapters()` in the FastAPI lifespan startup, **import-guarded** so a missing platform SDK degrades to a warning instead of crashing boot.

Inert and internal — registers four adapter classes in an in-memory dict; no external calls.

### Verification
- `tests/unit/test_adapter_registry_wiring.py` — registry register/list mechanism (passes locally); full default registration (skips locally when platform SDKs are absent, **runs in CI**).
- `ruff 0.15.15` ✅ · `black 26.5.1` ✅ · `isort 8.0.1` ✅ · `mypy 1.20.2` → **0 errors**.

> The other half of P1-5 — wiring `EmbedWidgets.tsx` to its backend — is a frontend task left as a follow-up.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_