### PR TITLE
fix(ci): unblock Frontend CI — eslint-plugin-react crash on ESLint 10

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -70,7 +70,11 @@ export default tseslint.config(
     },
     settings: {
       react: {
-        version: 'detect',
+        // Pin explicitly: eslint-plugin-react@7's "detect" path calls
+        // context.getFilename(), removed in ESLint 10, which crashes the
+        // linter (TypeError: getFilename is not a function). Matches the
+        // pinned react version in package.json.
+        version: '19.2',
       },
     },
     rules: {

--- a/frontend/src/views/EMQDiagnostics.tsx
+++ b/frontend/src/views/EMQDiagnostics.tsx
@@ -60,7 +60,7 @@ function todayIso(): string {
 function trendIcon(trend: 'up' | 'down' | 'flat') {
   if (trend === 'up') return <ArrowUpRight className="h-3.5 w-3.5 text-success" aria-label="up" />;
   if (trend === 'down')
-    return <ArrowDownRight className="h-3.5 w-3.5 text-danger" aria-label="down" />;
+    {return <ArrowDownRight className="h-3.5 w-3.5 text-danger" aria-label="down" />;}
   return <Minus className="h-3.5 w-3.5 text-muted-foreground" aria-label="flat" />;
 }
 

--- a/frontend/src/views/Settings.tsx
+++ b/frontend/src/views/Settings.tsx
@@ -2152,7 +2152,7 @@ function BillingSettings() {
         'Are you sure you want to cancel your subscription? You will retain access until the end of the current period.'
       )
     )
-      return;
+      {return;}
     try {
       await cancelSub.mutateAsync(undefined);
       toast({

--- a/frontend/src/views/console/OfflineConversions.tsx
+++ b/frontend/src/views/console/OfflineConversions.tsx
@@ -48,7 +48,7 @@ const REQUIRED_HEADERS = ['event_name', 'event_time'];
 function parseCSV(text: string): { rows: OfflineConversionRecord[]; error: string | null } {
   const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
   if (lines.length < 2)
-    return { rows: [], error: 'CSV must have a header row + at least one data row.' };
+    {return { rows: [], error: 'CSV must have a header row + at least one data row.' };}
   const headers = lines[0].split(',').map((h) => h.trim());
   for (const required of REQUIRED_HEADERS) {
     if (!headers.includes(required)) {


### PR DESCRIPTION
## Unblock Frontend CI — eslint-plugin-react crash on ESLint 10

Frontend CI's **Lint** step crashed (exit 2) on `main` and every PR:

```
TypeError: contextOrFilename.getFilename is not a function
  at resolveBasedir (eslint-plugin-react/lib/util/version.js)
  at detectReactVersion ...
Occurred while linting .../src/App.tsx
```

### Root cause
ESLint 10 removed `context.getFilename()` (use `context.filename`). `eslint-plugin-react@7.37.5`'s `version: 'detect'` path still calls it, so the linter crashes before evaluating any rules — not a code-quality failure.

### Fix
- **`eslint.config.js`** — pin `settings.react.version` to `'19.2'` (matches the pinned `react@19.2.7`), bypassing the broken auto-detection entirely. Surgical: no dependency bump, no rule changes.
- Apply the **3 pre-existing `curly` autofixes** the crash had been masking (`EMQDiagnostics.tsx`, `Settings.tsx`, `OfflineConversions.tsx`) so `--max-warnings 0` passes.

### Verification (locally, now that the linter runs)
- `eslint --max-warnings 0` → **exit 0** (0 errors, 0 warnings)
- `tsc --noEmit -p tsconfig.build.json` → clean

This makes Frontend CI's **Lint** and **Type check** steps green. (The separate **Security Scan/Trivy** failure is a dependency-CVE scan, unrelated.)

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_