### PR TITLE
fix(config): restore feature_knowledge_graph flag dropped in merge (+ backend test triage)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -361,6 +361,11 @@ class Settings(BaseSettings):
     feature_what_if_simulator: bool = Field(default=True)
     feature_automation_rules: bool = Field(default=True)
     feature_gdpr_compliance: bool = Field(default=True)
+    # Knowledge Graph requires the Apache AGE Postgres extension (not
+    # provisioned in the default image); shelved off by default until AGE is
+    # available. (Restored: lost in a #307/#308 merge while knowledge_graph.py
+    # still references it — its absence 500s every KG route.)
+    feature_knowledge_graph: bool = Field(default=False)
     # Campaign-builder connector beat tasks (ad-account sync, token refresh,
     # health checks) hit live platform APIs — opt-in, default off (P1-2).
     enable_campaign_builder_beat: bool = Field(default=False)


### PR DESCRIPTION
## Restore `feature_knowledge_graph` config flag (real regression) + backend test triage

I stood up a **live Postgres 16 + Redis** in-sandbox and ran the full `pytest tests/unit` suite (the exact CI command/env) to reproduce the Backend CI failure honestly — **no faking**.

### Result: 64 failed / 1686 passed

**One is a real product bug — fixed here:**
`config.py` lost `feature_knowledge_graph` during the **#307/#308 merge** (both inserted a flag right after `feature_gdpr_compliance`; the conflict kept #308's and dropped #307's). But `knowledge_graph.py:33` still reads `settings.feature_knowledge_graph` → **every Knowledge Graph route 500s at runtime**. Restored the flag (default `False`).
- ✅ Verified against the live DB: `test_knowledge_graph_shelved.py` 3/3 pass; ruff/black/isort/mypy clean.

### The other 63 failures are pre-existing test debt (not product regressions)
They were never caught because CI failed at the lint gate for the entire recent history, so the test step never ran. By category:

| Cause | ~Tests | Example |
|---|---|---|
| Stale test setup / mocked auth returns no user → `401 != 200` | ~30 | `test_deep_features_*` EMQ/tenants endpoint tests |
| Stale function signatures | ~12 | `creative_fatigue(metrics)` (now needs `baseline`); `signal_health(...event_loss=...)` |
| `bcrypt 5.0.0` × `passlib 1.7.4` incompat (shared with CI) | ~6 | `module 'bcrypt' has no attribute '__about__'` |
| Test-DB isolation (un-mocked `get_async_session()` in `get_subscription_info`) | ~few | `relation "tenants" does not exist` |
| CSP test doesn't set `app_env=development` | ~2 | `test_development_csp_allows_unsafe_eval` |
| Async event-loop fixtures | ~few | `Event loop is closed` |

These are real to fix but heterogeneous (each needs per-test investigation — mostly **updating stale tests to match evolved code**, not fixing the app). That's a sizable QA cleanup, scoped above.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_