### PR TITLE
fix(theme): pin public/marketing pages to dark to match landing.html

### DIFF
--- a/frontend/src/components/landing/PageLayout.tsx
+++ b/frontend/src/components/landing/PageLayout.tsx
@@ -73,7 +73,7 @@ export function PageLayout({ children }: PageLayoutProps) {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className="dark min-h-screen flex flex-col bg-background">
       {/* Ambient background */}
       <div
         className="fixed inset-0 pointer-events-none z-0"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,7 +14,12 @@
     }
   }
 
-  :root {
+  /* `.dark` is listed alongside `:root` so the dark tokens can be re-asserted
+     on a scoped subtree (e.g. the public/marketing shell, which is pinned dark
+     to match landing.html) even when an ancestor `<html class="light">` is in
+     light mode. */
+  :root,
+  .dark {
     /* ═══════════════════════════════════════════════════════════════
        STRATUM AI — FIGMA THEME (DARK, default)
        Bloomberg-density · Apple restraint · ember warmth

--- a/frontend/src/views/Landing.tsx
+++ b/frontend/src/views/Landing.tsx
@@ -39,7 +39,7 @@ export default function Landing() {
   }, [pagesData]);
 
   return (
-    <div className="min-h-screen bg-background font-sans">
+    <div className="dark min-h-screen bg-background font-sans">
       {/* Navigation */}
       <header
         className={`fixed top-0 left-0 right-0 z-50 transition-colors duration-200 ${

--- a/frontend/src/views/NotFound.tsx
+++ b/frontend/src/views/NotFound.tsx
@@ -12,7 +12,7 @@ export default function NotFound() {
 
   return (
     <div
-      className="min-h-screen flex items-center justify-center p-6 bg-background"
+      className="dark min-h-screen flex items-center justify-center p-6 bg-background"
     >
       <SEO
         title="Page Not Found"

--- a/frontend/src/views/plans/TierLandingPage.tsx
+++ b/frontend/src/views/plans/TierLandingPage.tsx
@@ -28,7 +28,7 @@ export default function TierLandingPage() {
   const gradientClass = `${content.visuals.gradientFrom} ${content.visuals.gradientTo}`;
 
   return (
-    <div key={tier} className="min-h-screen bg-surface-primary">
+    <div key={tier} className="dark min-h-screen bg-surface-primary">
       {/* Navigation Header */}
       <header className="fixed top-0 left-0 right-0 z-50 bg-surface-primary/80 backdrop-blur-lg border-b border-foreground/5">
         <div className="max-w-7xl mx-auto px-6 py-4">


### PR DESCRIPTION
## Summary

Fixes the broken **light-mode rendering** of the public/marketing pages by pinning them to **dark**, so they always match `landing.html` regardless of the visitor's OS theme.

## What was wrong

The marketing surfaces (home, all inner pages, tier landing, 404) are designed **dark-first** — `landing.html` is hardcoded dark, and these pages use dark-oriented literals (`text-white` headings/buttons, etc.). But the SPA resolves its theme from the visitor's OS (`prefers-color-scheme`), so on a **light-mode machine** the pages painted light and broke:

- white headings/buttons went **invisible** on the light background (e.g. the 404 page's "Page Not Found" heading + "Go Back" button), and
- dark-designed surfaces clashed with the light page background.

(The static `landing.html` looked fine because it ignores the theme system entirely.)

## Fix

Pin the public/marketing shell to dark, independent of the visitor's OS setting. The authenticated **dashboard stays dual-mode** — its theme toggle and the user's stored preference are untouched.

**Mechanism** (minimal, self-contained — 5 files, +10/−5):
- `index.css`: the dark token block now also applies to a `.dark` scope (`:root, .dark { … }`), so `.dark` can re-assert the dark CSS variables on a subtree even under `<html class="light">`.
- The public roots carry a `dark` class: **PageLayout** (all 26 inner pages), **Landing** (home), **TierLandingPage**, and **NotFound**.

Because `.dark` re-declares the dark custom properties on its subtree, the marketing pages render dark in any OS theme, and `text-white` literals become white-on-dark (visible) — no per-file `text-white` rewrites needed.

## Verification

- `npm run build`: ✅ succeeds.
- Compiled CSS confirms `:root,.dark{--background: 0 0% 4.3%; …}` (dark scope) with `.light{--background: 60 12% 97%; …}` still overriding at the `<html>` level; Tailwind `dark:` variants compile to `:is(.dark *)`.
- `eslint --max-warnings 0` on the changed TSX: ✅ clean.

## Note

This is independent of, and complementary to, the **redeploy** still needed for #315/#316/#318 to go live — the screenshots that prompted this were from a stale build (old rainbow feature cards). Once `main` is deployed, the marketing pages will show the new ember theme, pinned dark.

Opened as a **draft** for review.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_