### PR TITLE
feat(docs): real article pages for every /docs/* link (fix 404s)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -245,6 +245,9 @@ const DPAPage = lazyWithRetry(() => import('./views/pages/legal/DPA'));
 
 // Public pages (Resources)
 const DocsPage = lazyWithRetry(() => import('./views/pages/resources/Docs'));
+const DocArticlePage = lazyWithRetry(
+  () => import('./views/pages/resources/docs/DocArticlePage')
+);
 const ChangelogPage = lazyWithRetry(() => import('./views/pages/resources/Changelog'));
 const CaseStudiesPage = lazyWithRetry(() => import('./views/pages/resources/CaseStudies'));
 const ResourcesPage = lazyWithRetry(() => import('./views/pages/resources/Resources'));
@@ -707,6 +710,16 @@ function App() {
                           <ErrorBoundary message="Failed to load the documentation page">
                             <LazyRoute>
                               <DocsPage />
+                            </LazyRoute>
+                          </ErrorBoundary>
+                        }
+                      />
+                      <Route
+                        path="/docs/*"
+                        element={
+                          <ErrorBoundary message="Failed to load the documentation page">
+                            <LazyRoute>
+                              <DocArticlePage />
                             </LazyRoute>
                           </ErrorBoundary>
                         }

--- a/frontend/src/views/pages/resources/Docs.tsx
+++ b/frontend/src/views/pages/resources/Docs.tsx
@@ -10,86 +10,8 @@ import { CTA } from '@/components/landing/CTA';
 import { MktHero, MktSectionHeader, MktCard } from '@/components/landing/marketing';
 import { pageSEO, SEO } from '@/components/common/SEO';
 import { sanitizeHtml } from '@/lib/sanitize';
-import {
-  AcademicCapIcon,
-  ArrowRightIcon,
-  BookOpenIcon,
-  CloudIcon,
-  CodeBracketIcon,
-  CpuChipIcon,
-  MagnifyingGlassIcon,
-  PlayIcon,
-  ShieldCheckIcon,
-} from '@heroicons/react/24/outline';
-
-const docCategories = [
-  {
-    title: 'Getting Started',
-    description: 'Quick start guides to get you up and running',
-    icon: PlayIcon,
-    links: [
-      { name: 'Quick Start Guide', href: '/docs/quickstart' },
-      { name: 'Installation', href: '/docs/installation' },
-      { name: 'Authentication', href: '/docs/auth' },
-      { name: 'First Campaign', href: '/docs/first-campaign' },
-    ],
-  },
-  {
-    title: 'API Reference',
-    description: 'Complete API documentation with examples',
-    icon: CodeBracketIcon,
-    links: [
-      { name: 'REST API', href: '/api-docs' },
-      { name: 'Webhooks', href: '/docs/webhooks' },
-      { name: 'SDKs', href: '/docs/sdks' },
-      { name: 'Rate Limits', href: '/docs/rate-limits' },
-    ],
-  },
-  {
-    title: 'Trust Engine',
-    description: 'Learn about our trust-gated automation',
-    icon: ShieldCheckIcon,
-    links: [
-      { name: 'Signal Health', href: '/docs/signal-health' },
-      { name: 'Trust Gates', href: '/docs/trust-gates' },
-      { name: 'Autopilot Rules', href: '/docs/autopilot' },
-      { name: 'Thresholds', href: '/docs/thresholds' },
-    ],
-  },
-  {
-    title: 'CDP',
-    description: 'Customer Data Platform documentation',
-    icon: CpuChipIcon,
-    links: [
-      { name: 'Profiles', href: '/docs/cdp/profiles' },
-      { name: 'Segments', href: '/docs/cdp/segments' },
-      { name: 'Identity Resolution', href: '/docs/cdp/identity' },
-      { name: 'Audience Sync', href: '/docs/cdp/audience-sync' },
-    ],
-  },
-  {
-    title: 'Integrations',
-    description: 'Connect with ad platforms and tools',
-    icon: CloudIcon,
-    links: [
-      { name: 'Meta Ads', href: '/docs/integrations/meta' },
-      { name: 'Google Ads', href: '/docs/integrations/google' },
-      { name: 'TikTok Ads', href: '/docs/integrations/tiktok' },
-      { name: 'CRM Systems', href: '/docs/integrations/crm' },
-    ],
-  },
-  {
-    title: 'Tutorials',
-    description: 'Step-by-step guides and best practices',
-    icon: AcademicCapIcon,
-    links: [
-      { name: 'Video Tutorials', href: '/docs/tutorials/videos' },
-      { name: 'Use Cases', href: '/docs/tutorials/use-cases' },
-      { name: 'Best Practices', href: '/docs/tutorials/best-practices' },
-      { name: 'Troubleshooting', href: '/docs/tutorials/troubleshooting' },
-    ],
-  },
-];
+import { BookOpenIcon, MagnifyingGlassIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
+import { docsNav as docCategories } from './docs/registry';
 
 const popularArticles = [
   { title: 'Setting up your first Trust Gate', views: '12.5K', time: '5 min' },

--- a/frontend/src/views/pages/resources/docs/DocArticlePage.tsx
+++ b/frontend/src/views/pages/resources/docs/DocArticlePage.tsx
@@ -1,0 +1,243 @@
+/**
+ * Dynamic documentation article page — landing-themed (ink + ember).
+ * Serves every `/docs/*` route from the content registry.
+ */
+
+import { useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageLayout } from '@/components/landing/PageLayout';
+import { CTA } from '@/components/landing/CTA';
+import { SEO } from '@/components/common/SEO';
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ClockIcon,
+  ExclamationTriangleIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+import { docsNav, getDocArticle, docArticleOrder, docArticles } from './registry';
+import type { DocBlock } from './types';
+
+function calloutClasses(tone: 'info' | 'warning' | 'success' | undefined): string {
+  switch (tone) {
+    case 'warning':
+      return 'bg-warning/10 border-warning/30 text-warning';
+    case 'success':
+      return 'bg-success/10 border-success/30 text-success';
+    default:
+      return 'bg-accent/10 border-accent/30 text-accent';
+  }
+}
+
+function Block({ block }: { block: DocBlock }) {
+  switch (block.type) {
+    case 'heading':
+      return (
+        <h2 className="text-h2 text-foreground font-semibold mt-10 mb-4 scroll-mt-28">
+          {block.text}
+        </h2>
+      );
+    case 'subheading':
+      return <h3 className="text-h3 text-foreground font-semibold mt-7 mb-2">{block.text}</h3>;
+    case 'paragraph':
+      return <p className="text-body text-muted-foreground leading-relaxed mb-4">{block.text}</p>;
+    case 'list':
+      return block.ordered ? (
+        <ol className="list-decimal pl-6 space-y-2 mb-4 text-body text-muted-foreground">
+          {block.items.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ol>
+      ) : (
+        <ul className="list-disc pl-6 space-y-2 mb-4 text-body text-muted-foreground">
+          {block.items.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      );
+    case 'code':
+      return (
+        <div className="mb-5 rounded-xl border border-border bg-card overflow-hidden">
+          {block.language ? (
+            <div className="px-4 py-2 border-b border-border text-micro uppercase tracking-wide text-muted-foreground font-mono">
+              {block.language}
+            </div>
+          ) : null}
+          <pre className="p-4 overflow-x-auto">
+            <code className="font-mono text-meta text-foreground whitespace-pre">{block.code}</code>
+          </pre>
+        </div>
+      );
+    case 'callout':
+      return (
+        <div className={`mb-5 flex gap-3 rounded-xl border p-4 ${calloutClasses(block.tone)}`}>
+          {block.tone === 'warning' ? (
+            <ExclamationTriangleIcon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+          ) : (
+            <InformationCircleIcon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+          )}
+          <div>
+            {block.title ? <p className="font-semibold mb-1">{block.title}</p> : null}
+            <p className="text-body text-foreground/90 leading-relaxed">{block.text}</p>
+          </div>
+        </div>
+      );
+    default:
+      return null;
+  }
+}
+
+function DocNotFound({ slug }: { slug: string }) {
+  return (
+    <PageLayout>
+      <SEO title="Documentation Not Found" description="That documentation page could not be found." noIndex />
+      <section className="py-24 lg:py-32">
+        <div className="max-w-2xl mx-auto px-6 text-center">
+          <p className="text-meta uppercase text-secondary mb-3">Documentation</p>
+          <h1 className="text-display-xs md:text-display-sm text-foreground mb-4">
+            We couldn&apos;t find <span className="text-gradient-primary">that page</span>
+          </h1>
+          <p className="text-body text-muted-foreground mb-2">
+            There&apos;s no documentation article at
+          </p>
+          <p className="font-mono text-meta text-foreground/80 mb-8 break-all">/docs/{slug}</p>
+          <Link
+            to="/docs"
+            className="inline-flex items-center gap-2 px-7 py-3.5 rounded-full bg-stratum-500 text-primary-foreground font-semibold text-body hover:brightness-110 hover:shadow-glow transition-all duration-200"
+          >
+            <ArrowLeftIcon className="w-5 h-5" />
+            Back to docs
+          </Link>
+        </div>
+      </section>
+    </PageLayout>
+  );
+}
+
+export default function DocArticlePage() {
+  const params = useParams();
+  const slug = (params['*'] ?? '').replace(/^\/+|\/+$/g, '');
+  const article = getDocArticle(slug);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [slug]);
+
+  if (!article) {
+    return <DocNotFound slug={slug} />;
+  }
+
+  const idx = docArticleOrder.indexOf(article.slug);
+  const prevSlug = idx > 0 ? docArticleOrder[idx - 1] : undefined;
+  const nextSlug = idx >= 0 && idx < docArticleOrder.length - 1 ? docArticleOrder[idx + 1] : undefined;
+  const prev = prevSlug ? docArticles[prevSlug] : undefined;
+  const next = nextSlug ? docArticles[nextSlug] : undefined;
+
+  return (
+    <PageLayout>
+      <SEO
+        title={`${article.title} — Docs`}
+        description={article.description}
+        url={`https://stratumai.app/docs/${article.slug}`}
+      />
+
+      <div className="max-w-7xl mx-auto px-6 lg:px-8 pt-12 pb-24">
+        {/* Breadcrumb */}
+        <nav className="flex items-center gap-2 text-meta text-muted-foreground mb-8" aria-label="Breadcrumb">
+          <Link to="/docs" className="hover:text-secondary transition-colors">
+            Docs
+          </Link>
+          <span aria-hidden="true">/</span>
+          <span className="text-foreground/70">{article.category}</span>
+        </nav>
+
+        <div className="grid lg:grid-cols-[16rem_1fr] gap-10 lg:gap-14">
+          {/* Sidebar */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-28 space-y-7">
+              {docsNav.map((cat) => (
+                <div key={cat.title}>
+                  <p className="text-meta uppercase text-muted-foreground mb-2">{cat.title}</p>
+                  <ul className="space-y-1.5 border-l border-border">
+                    {cat.links.map((link) => {
+                      const active = link.href === `/docs/${article.slug}`;
+                      return (
+                        <li key={link.href}>
+                          <Link
+                            to={link.href}
+                            className={`-ml-px block border-l pl-3 py-0.5 text-body transition-colors ${
+                              active
+                                ? 'border-secondary text-secondary font-medium'
+                                : 'border-transparent text-muted-foreground hover:text-foreground hover:border-foreground/30'
+                            }`}
+                          >
+                            {link.name}
+                          </Link>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          {/* Article */}
+          <article className="min-w-0 max-w-3xl">
+            <p className="text-meta uppercase text-secondary mb-3">{article.category}</p>
+            <h1 className="text-display-xs md:text-display-sm text-foreground mb-4">{article.title}</h1>
+            <p className="text-body text-muted-foreground leading-relaxed mb-3">
+              {article.description}
+            </p>
+            <div className="flex items-center gap-2 text-meta text-muted-foreground mb-10 pb-8 border-b border-border">
+              <ClockIcon className="w-4 h-4" />
+              <span>{article.readTime} read</span>
+            </div>
+
+            <div>
+              {article.blocks.map((block, i) => (
+                <Block key={i} block={block} />
+              ))}
+            </div>
+
+            {/* Prev / next */}
+            <div className="mt-14 pt-8 border-t border-border grid sm:grid-cols-2 gap-4">
+              {prev ? (
+                <Link
+                  to={`/docs/${prev.slug}`}
+                  className="group rounded-2xl bg-card border border-border p-5 hover:border-secondary/30 transition-colors"
+                >
+                  <span className="flex items-center gap-1.5 text-meta text-muted-foreground mb-1">
+                    <ArrowLeftIcon className="w-3.5 h-3.5" /> Previous
+                  </span>
+                  <span className="text-body text-foreground font-medium group-hover:text-secondary transition-colors">
+                    {prev.title}
+                  </span>
+                </Link>
+              ) : (
+                <span />
+              )}
+              {next ? (
+                <Link
+                  to={`/docs/${next.slug}`}
+                  className="group rounded-2xl bg-card border border-border p-5 hover:border-secondary/30 transition-colors text-right"
+                >
+                  <span className="flex items-center justify-end gap-1.5 text-meta text-muted-foreground mb-1">
+                    Next <ArrowRightIcon className="w-3.5 h-3.5" />
+                  </span>
+                  <span className="text-body text-foreground font-medium group-hover:text-secondary transition-colors">
+                    {next.title}
+                  </span>
+                </Link>
+              ) : (
+                <span />
+              )}
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <CTA />
+    </PageLayout>
+  );
+}

--- a/frontend/src/views/pages/resources/docs/content/apiReference.ts
+++ b/frontend/src/views/pages/resources/docs/content/apiReference.ts
@@ -1,0 +1,187 @@
+import type { DocArticle } from '../types';
+
+export const apiReferenceArticles: DocArticle[] = [
+  {
+    slug: 'webhooks',
+    category: 'API Reference',
+    title: 'Webhooks',
+    description:
+      'Receive real-time, server-to-server notifications when signal health, incidents, or automations change.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Webhooks let Stratum push events to your backend the moment something changes — no polling required. They are the server-side counterpart to the dashboard’s live updates: the dashboard streams over WebSocket and SSE, while your systems integrate over webhooks.',
+      },
+      { type: 'heading', text: 'What you can subscribe to' },
+      {
+        type: 'list',
+        items: [
+          'Signal health and EMQ changes — when a score crosses a threshold or shifts state.',
+          'Incidents — opened, updated, or resolved tracking and platform incidents.',
+          'Autopilot enforcement-mode changes — Advisory, Soft-Block, or Hard-Block transitions.',
+          'Automation action status — when an action is executed, held, or blocked by the trust gate.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Register an endpoint under Settings → Webhooks, choose the event types you care about, and Stratum will start delivering. Every delivery is a JSON POST to your URL.',
+      },
+      { type: 'heading', text: 'The delivery payload' },
+      {
+        type: 'paragraph',
+        text: 'Each delivery has a stable envelope: a unique event id, an event type, a timestamp, the tenant id, and a typed data object. Use the id for idempotency so a redelivery is processed at most once.',
+      },
+      {
+        type: 'code',
+        language: 'json',
+        code: '{\n  "id": "evt_9f3a1c2b",\n  "type": "signal_health.changed",\n  "created_at": "2026-06-07T14:22:08Z",\n  "tenant_id": "wsp_3k8d",\n  "data": {\n    "signal_id": "sig_meta_capi",\n    "previous_score": 72,\n    "current_score": 58,\n    "state": "degraded"\n  }\n}',
+      },
+      { type: 'heading', text: 'Verify the signature' },
+      {
+        type: 'paragraph',
+        text: 'Every request carries an X-Stratum-Signature header — an HMAC-SHA256 of the raw request body, keyed with your webhook secret. Recompute it over the unparsed body and compare with a constant-time function so you reject any forged or replayed delivery.',
+      },
+      {
+        type: 'code',
+        language: 'javascript',
+        code: "import crypto from 'node:crypto';\n\nfunction verify(rawBody, header, secret) {\n  const expected = crypto\n    .createHmac('sha256', secret)\n    .update(rawBody)\n    .digest('hex');\n  const a = Buffer.from(expected);\n  const b = Buffer.from(header);\n  return a.length === b.length && crypto.timingSafeEqual(a, b);\n}",
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Hash the raw body, not the parsed JSON',
+        text: 'Re-serializing the payload can change byte order or whitespace and break the signature. Verify against the exact bytes you received, then parse.',
+      },
+      { type: 'heading', text: 'Retries and reliability' },
+      {
+        type: 'list',
+        items: [
+          'Respond 2xx quickly — acknowledge first, then process asynchronously.',
+          'Any non-2xx response triggers retries with exponential backoff over the following hours.',
+          'Deduplicate on the event id; the same event may be delivered more than once.',
+          'Order is best-effort — rely on created_at and the score values rather than arrival order.',
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'sdks',
+    category: 'API Reference',
+    title: 'SDKs',
+    description:
+      'Official JavaScript/TypeScript and Python clients that wrap the REST API, signals, the CDP, and audience sync.',
+    readTime: '5 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'The official SDKs give you typed access to the same REST surface documented in the API explorer — signal endpoints, the CDP profile and event store, and audience sync — without hand-rolling requests, auth headers, or retries.',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        title: 'Two layers, one platform',
+        text: 'The server SDKs are for backend calls with your secret API key. For browser conversion tracking, use the lightweight web tag and its stratum(\'track\', ...) helper covered in Installation — never put a secret key in frontend code.',
+      },
+      { type: 'heading', text: 'JavaScript / TypeScript' },
+      {
+        type: 'paragraph',
+        text: 'Install from npm and initialize the client with an API key read from your environment. The client is fully typed, so signals, profiles, and audiences come back as concrete shapes.',
+      },
+      {
+        type: 'code',
+        language: 'bash',
+        code: 'npm install @stratumai/sdk',
+      },
+      {
+        type: 'code',
+        language: 'typescript',
+        code: "import { Stratum } from '@stratumai/sdk';\n\nconst stratum = new Stratum({ apiKey: process.env.STRATUM_API_KEY });\n\n// List current signals and their health\nconst signals = await stratum.signals.list();\nfor (const s of signals) {\n  console.log(s.name, s.health, s.state);\n}",
+      },
+      { type: 'heading', text: 'Python' },
+      {
+        type: 'paragraph',
+        text: 'Install from PyPI and construct the client the same way. The Python SDK mirrors the JS surface, so the resource names and methods line up across both languages.',
+      },
+      {
+        type: 'code',
+        language: 'python',
+        code: 'pip install stratum-ai',
+      },
+      {
+        type: 'code',
+        language: 'python',
+        code: 'import os\nfrom stratum import Stratum\n\nstratum = Stratum(api_key=os.environ["STRATUM_API_KEY"])\n\n# Send a server-side conversion event\nstratum.events.track(\n    name="Purchase",\n    value=129.0,\n    currency="USD",\n    user={"email_sha256": "9c1185a5c5e9fc54..."},\n)',
+      },
+      { type: 'heading', text: 'What the SDKs handle for you' },
+      {
+        type: 'list',
+        items: [
+          'Bearer authentication and base-URL configuration.',
+          'Automatic retries with backoff, including 429 Retry-After handling.',
+          'Typed resources for signals, CDP profiles and events, and audience sync.',
+          'Pagination cursors so list calls iterate cleanly over large result sets.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Keep PII out of the clear',
+        text: 'When passing user identifiers to the CDP or audience sync, lower-case, trim, and SHA-256 hash email and phone before they leave your servers. The SDKs accept pre-hashed identifiers directly.',
+      },
+    ],
+  },
+  {
+    slug: 'rate-limits',
+    category: 'API Reference',
+    title: 'Rate Limits',
+    description:
+      'How Stratum meters API traffic per tenant, the headers you get back, and how to handle a 429.',
+    readTime: '4 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Stratum applies per-tenant rate limits to keep the platform fast and fair. Limits are enforced with a Redis-backed, token-bucket scheme: each workspace refills a budget of requests over time and spends from it as you call the API.',
+      },
+      { type: 'heading', text: 'Read the limit headers' },
+      {
+        type: 'paragraph',
+        text: 'Every response includes your current standing, so you can pace requests before you ever hit a wall.',
+      },
+      {
+        type: 'list',
+        items: [
+          'X-RateLimit-Limit — the size of your bucket for this window.',
+          'X-RateLimit-Remaining — requests left before throttling kicks in.',
+          'X-RateLimit-Reset — Unix timestamp when the bucket refills.',
+        ],
+      },
+      { type: 'heading', text: 'When you exceed the limit' },
+      {
+        type: 'paragraph',
+        text: 'Over-limit requests return 429 Too Many Requests with a Retry-After header telling you how many seconds to wait. Honor it rather than retrying immediately.',
+      },
+      {
+        type: 'code',
+        language: 'http',
+        code: 'HTTP/1.1 429 Too Many Requests\nRetry-After: 12\nX-RateLimit-Limit: 600\nX-RateLimit-Remaining: 0\nX-RateLimit-Reset: 1749306140\nContent-Type: application/json\n\n{\n  "error": "rate_limited",\n  "message": "Too many requests. Retry after 12 seconds."\n}',
+      },
+      { type: 'heading', text: 'Stay under the limit' },
+      {
+        type: 'list',
+        items: [
+          'Back off exponentially on 429, seeding the first delay from Retry-After.',
+          'Batch server-side events instead of sending one request per event.',
+          'Cache reads — signal health and profile lookups rarely need to be re-fetched every second.',
+          'Let the official SDKs absorb retries and Retry-After handling for you.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        title: 'Limits scale with your plan',
+        text: 'Rate limits rise across the Starter, Professional, and Enterprise tiers. If you are consistently throttled despite batching and backoff, upgrading your subscription raises the per-tenant budget.',
+      },
+    ],
+  },
+];

--- a/frontend/src/views/pages/resources/docs/content/cdp.ts
+++ b/frontend/src/views/pages/resources/docs/content/cdp.ts
@@ -1,0 +1,262 @@
+import type { DocArticle } from '../types';
+
+export const cdpArticles: DocArticle[] = [
+  {
+    slug: 'cdp/profiles',
+    category: 'CDP',
+    title: 'Profiles',
+    description:
+      'How Stratum unifies events and identifiers into a single customer record with computed traits and lifecycle stages.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'The Customer Data Platform (CDP) is Stratum’s profile and event store. A profile is a unified customer record that combines data from every connected source and touchpoint into one view — the foundation the rest of the platform reasons about.',
+      },
+      { type: 'heading', text: 'What a unified profile contains' },
+      {
+        type: 'list',
+        items: [
+          'Identity information — emails, phone numbers, and device IDs linked to the person.',
+          'Behavioral events — the full timeline of tracked actions, from page views to purchases.',
+          'Computed traits — attributes derived from that event history.',
+          'Segment memberships — every dynamic segment the profile currently matches.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Because the record is assembled continuously, a profile is never stale: a new event, a fresh identifier, or a changed trait updates membership and lifecycle stage in place.',
+      },
+      { type: 'heading', text: 'Computed traits' },
+      {
+        type: 'paragraph',
+        text: 'Computed traits are derived from a profile’s event history rather than written directly. Stratum maintains them automatically as new events arrive:',
+      },
+      {
+        type: 'list',
+        items: [
+          'Total purchases — count of completed orders.',
+          'Days since last activity — recency of the most recent event.',
+          'Average order value — mean revenue per order.',
+          'Lifetime value (LTV) — predicted total revenue across the relationship.',
+        ],
+      },
+      { type: 'heading', text: 'Lifecycle stages' },
+      {
+        type: 'paragraph',
+        text: 'Every profile sits in exactly one lifecycle stage, advancing as identity resolves and behavior changes:',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Anonymous — no identity yet, only a device or session.',
+          'Known — identified via email or login.',
+          'Lead — has expressed interest.',
+          'Customer — has made a purchase.',
+          'Active — recently engaged.',
+          'At Risk — engagement is declining.',
+          'Churned — no recent activity.',
+        ],
+      },
+      { type: 'heading', text: 'Querying profiles' },
+      {
+        type: 'paragraph',
+        text: 'Read profiles programmatically from the CDP endpoint with your workspace-scoped API key. Results include identity, computed traits, and current segment memberships.',
+      },
+      {
+        type: 'code',
+        language: 'bash',
+        code: 'curl "https://api.stratumai.app/api/v1/cdp/profiles?lifecycle=at_risk" \\\n  -H "Authorization: Bearer $STRATUM_API_KEY"',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'Profiles are tenant-isolated. An API key only ever returns records belonging to its own workspace.',
+      },
+    ],
+  },
+  {
+    slug: 'cdp/segments',
+    category: 'CDP',
+    title: 'Segments',
+    description:
+      'Build behavioral, demographic, and predictive segments that re-evaluate themselves as profiles change.',
+    readTime: '7 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'A segment is a dynamic group of profiles matching specific criteria. Segments are not static lists — they re-evaluate continuously, so a profile joins or leaves the moment its data crosses the rule boundary.',
+      },
+      { type: 'heading', text: 'Segment types' },
+      {
+        type: 'list',
+        items: [
+          'Behavioral — defined by event patterns, such as “purchased twice in 30 days” or “viewed pricing but never bought.”',
+          'Demographic — defined by profile attributes, such as country, plan tier, or acquisition source.',
+          'Predictive — defined by an ML model output, such as churn risk above a threshold.',
+        ],
+      },
+      { type: 'heading', text: 'How rules evaluate dynamically' },
+      {
+        type: 'paragraph',
+        text: 'Each segment carries a rule set evaluated against live profile data. When a new event arrives or a computed trait updates, Stratum re-checks affected profiles and adjusts membership in place — no manual rebuild, no nightly batch you have to wait on.',
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        title: 'Membership is always current',
+        text: 'Because segments reference computed traits like days since last activity, a profile can age into an “At Risk” segment automatically without any event being fired.',
+      },
+      { type: 'heading', text: 'RFM analysis' },
+      {
+        type: 'paragraph',
+        text: 'For commerce workflows, Stratum supports RFM segmentation, scoring each profile on three axes:',
+      },
+      {
+        type: 'list',
+        items: [
+          'Recency — how recently did they purchase?',
+          'Frequency — how often do they purchase?',
+          'Monetary — how much do they spend?',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'RFM lets you isolate high-value cohorts — recent, frequent, big spenders — and treat declining ones differently from loyal ones.',
+      },
+      { type: 'heading', text: 'Creating a segment' },
+      {
+        type: 'paragraph',
+        text: 'Create segments in the dashboard or via the API. Post a rule definition and Stratum begins evaluating it against every profile immediately.',
+      },
+      {
+        type: 'code',
+        language: 'bash',
+        code: 'curl -X POST https://api.stratumai.app/api/v1/cdp/segments \\\n  -H "Authorization: Bearer $STRATUM_API_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "name": "High-value at risk",\n    "type": "behavioral",\n    "rules": {\n      "all": [\n        { "trait": "total_purchases", "op": "gte", "value": 3 },\n        { "trait": "days_since_last_activity", "op": "gte", "value": 45 }\n      ]\n    }\n  }\'',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'Once a segment exists you can push it to ad platforms with Audience Sync — see the next article.',
+      },
+    ],
+  },
+  {
+    slug: 'cdp/identity',
+    category: 'CDP',
+    title: 'Identity Resolution',
+    description:
+      'How disparate identifiers collapse into one profile as a visitor moves from anonymous to known to customer.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Identity resolution is the process of connecting disparate identifiers to a single customer profile. A person rarely arrives fully identified — they browse anonymously, log in later, and purchase later still. Stratum stitches those moments together so they describe one human, not three.',
+      },
+      { type: 'heading', text: 'The identity graph' },
+      {
+        type: 'paragraph',
+        text: 'Each profile is backed by an identity graph: a representation of how identifiers — email, phone, device IDs — connect to form the unified record. As new identifiers appear alongside known ones, edges are added and the graph grows.',
+      },
+      { type: 'heading', text: 'The resolution flow' },
+      {
+        type: 'paragraph',
+        text: 'A typical journey advances through two resolution steps:',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Anonymous → Known — a device or session profile gains an email or login, so the anonymous activity is now attributed to a known person.',
+          'Known → Customer — that known person completes a purchase, advancing the lifecycle stage and enriching their computed traits.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        title: 'No history is lost',
+        text: 'When an anonymous profile is identified, its earlier events fold into the resolved profile — so the pre-login browsing that led to a purchase still counts.',
+      },
+      { type: 'heading', text: 'How deterministic identifiers merge' },
+      {
+        type: 'paragraph',
+        text: 'Stratum merges on deterministic matches: a shared, exact identifier such as the same email or the same device ID seen on two profiles. When a match is found, the records are merged into one identity graph and their events, traits, and segment memberships are recomputed against the combined history.',
+      },
+      { type: 'heading', text: 'What happens on login and on purchase' },
+      {
+        type: 'list',
+        items: [
+          'On login — the session’s device ID links to the authenticated email, collapsing anonymous activity into the Known profile.',
+          'On purchase — the order ties the profile to a verified customer identifier, moving the lifecycle stage to Customer and updating total purchases, average order value, and LTV.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'Identifiers used for matching are stored as encrypted PII at rest. Raw values are never exposed in profile reads or pushed to external platforms.',
+      },
+    ],
+  },
+  {
+    slug: 'cdp/audience-sync',
+    category: 'CDP',
+    title: 'Audience Sync',
+    description:
+      'Push CDP segments to Meta, Google, TikTok, and Snapchat for targeting — privately, and kept fresh automatically.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Audience Sync pushes a CDP segment to advertising platforms so you can target — or suppress — those exact profiles in your campaigns. Build the audience once in Stratum and let it stay current everywhere it is used.',
+      },
+      { type: 'heading', text: 'The sync flow' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Select a segment — choose any behavioral, demographic, or predictive segment from the CDP.',
+          'Connect a platform — pick a destination you have already authorized via OAuth.',
+          'Push — Stratum hashes the matchable identifiers and uploads the audience.',
+          'Auto-refresh — configure a refresh cadence so membership changes propagate without a manual re-push.',
+        ],
+      },
+      { type: 'heading', text: 'Destination platforms' },
+      {
+        type: 'list',
+        items: [
+          'Meta Custom Audiences',
+          'Google Customer Match',
+          'TikTok Custom Audiences',
+          'Snapchat Audience Match',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Your PII never leaves your control',
+        text: 'Before any audience is uploaded, email and phone identifiers are lower-cased, trimmed, and SHA-256 hashed. Only the hashes are sent to the platform — raw PII never leaves Stratum, and it remains encrypted at rest.',
+      },
+      { type: 'heading', text: 'Match-rate tracking' },
+      {
+        type: 'paragraph',
+        text: 'After each push, Stratum records the match rate — the share of hashed identifiers the destination could resolve to its own users. Tracking match rate over time tells you whether an audience is large and clean enough to be worth targeting, and surfaces drops caused by stale or low-quality identifiers.',
+      },
+      { type: 'heading', text: 'Syncing via the API' },
+      {
+        type: 'paragraph',
+        text: 'Trigger a sync programmatically by referencing a segment and a connected destination. Stratum handles hashing and upload, then returns a job you can poll for match-rate results.',
+      },
+      {
+        type: 'code',
+        language: 'bash',
+        code: 'curl -X POST https://api.stratumai.app/api/v1/audience-sync \\\n  -H "Authorization: Bearer $STRATUM_API_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "segment_id": "seg_high_value_at_risk",\n    "destination": "meta_custom_audience",\n    "auto_refresh": "daily"\n  }\'',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'With auto-refresh enabled, profiles that leave the segment are removed from the destination audience on the next refresh, and new matches are added — keeping spend aimed at the right people.',
+      },
+    ],
+  },
+];

--- a/frontend/src/views/pages/resources/docs/content/gettingStarted.ts
+++ b/frontend/src/views/pages/resources/docs/content/gettingStarted.ts
@@ -1,0 +1,222 @@
+import type { DocArticle } from '../types';
+
+export const gettingStartedArticles: DocArticle[] = [
+  {
+    slug: 'quickstart',
+    category: 'Getting Started',
+    title: 'Quick Start Guide',
+    description:
+      'Go from sign-up to your first trust-gated automation in about ten minutes.',
+    readTime: '5 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Stratum AI is a revenue operating system with trust-gated autopilot: automations only execute when signal health passes your safety thresholds. This guide walks you through the fastest path to a working setup — connect a platform, watch signal health populate, and arm your first automation.',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        title: 'Before you begin',
+        text: 'You need an active workspace and admin access to at least one ad platform (Meta, Google, TikTok, or Snapchat). A 14-day trial is enough to complete every step here.',
+      },
+      { type: 'heading', text: 'Step 1 — Create your workspace' },
+      {
+        type: 'paragraph',
+        text: 'Each workspace is an isolated tenant with its own users, integrations, and analytics. After verifying your email you will land in an empty Overview — the action-first dashboard that sorts everything by what needs your attention.',
+      },
+      { type: 'heading', text: 'Step 2 — Connect a platform' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Open Integrations and choose a provider.',
+          'Complete the OAuth consent flow — Stratum never sees your password; we store only an encrypted refresh token.',
+          'Select the ad accounts you want Stratum to read.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Within a few minutes the signal collectors begin pulling metrics, events, and webhook deliveries from the connected account.',
+      },
+      { type: 'heading', text: 'Step 3 — Watch signal health populate' },
+      {
+        type: 'paragraph',
+        text: 'Signal Health is a composite 0–100 score of how reliable your data is right now. It blends Event Match Quality, API health, event loss, platform stability, and data quality. Give it 15–30 minutes after connecting to settle.',
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        text: 'A score of 70 or above is healthy — green — and autopilot is eligible to run. 40–69 is degraded and holds; below 40 blocks and requires manual review.',
+      },
+      { type: 'heading', text: 'Step 4 — Arm your first automation' },
+      {
+        type: 'paragraph',
+        text: 'Create a simple budget-pacing or bid automation and leave it in Advisory mode at first. Advisory surfaces the action Stratum would take without executing it, so you can build trust in the recommendations before handing over control.',
+      },
+      { type: 'heading', text: 'Next steps' },
+      {
+        type: 'list',
+        items: [
+          'Read Installation to wire the SDK or CAPI into your site.',
+          'Read Authentication to issue an API key for programmatic access.',
+          'Follow First Campaign for an end-to-end automation walkthrough.',
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'installation',
+    category: 'Getting Started',
+    title: 'Installation',
+    description:
+      'Add the Stratum tag and server-side events so the platform can measure and act on your traffic.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Stratum measures two complementary streams: client-side events from the browser tag and server-side events from the Conversions API (CAPI). Using both maximizes Event Match Quality and keeps signal health resilient to browser limitations.',
+      },
+      { type: 'heading', text: 'Install the web tag' },
+      {
+        type: 'paragraph',
+        text: 'Drop the snippet into the <head> of every page. It loads asynchronously and will not block rendering.',
+      },
+      {
+        type: 'code',
+        language: 'html',
+        code: '<script\n  async\n  src="https://cdn.stratumai.app/s.js"\n  data-workspace="YOUR_WORKSPACE_ID"\n></script>',
+      },
+      {
+        type: 'paragraph',
+        text: 'Track a conversion by calling the global helper once the tag has loaded:',
+      },
+      {
+        type: 'code',
+        language: 'javascript',
+        code: "stratum('track', 'Purchase', {\n  value: 129.0,\n  currency: 'USD',\n  order_id: 'A1B2C3',\n});",
+      },
+      { type: 'heading', text: 'Send server-side events (recommended)' },
+      {
+        type: 'paragraph',
+        text: 'Server events are not affected by ad blockers or cookie restrictions, so they raise match quality. POST them to the events endpoint with your secret API key.',
+      },
+      {
+        type: 'code',
+        language: 'bash',
+        code: 'curl -X POST https://api.stratumai.app/api/v1/events \\\n  -H "Authorization: Bearer $STRATUM_API_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "name": "Purchase",\n    "value": 129.0,\n    "currency": "USD",\n    "user": { "email": "h@shed.example" }\n  }\'',
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Hash PII before it leaves your servers',
+        text: 'Email and phone identifiers should be lower-cased, trimmed, and SHA-256 hashed before being sent. Stratum never requires raw PII for matching.',
+      },
+      { type: 'heading', text: 'Verify the install' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Open Integrations → Signal Health and confirm events are arriving.',
+          'Trigger a test conversion and watch it appear in the live event stream within seconds.',
+          'Check that Event Match Quality climbs as identifiers are matched.',
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'auth',
+    category: 'Getting Started',
+    title: 'Authentication',
+    description:
+      'How API keys, OAuth, JWT sessions, and MFA work together to secure access to Stratum.',
+    readTime: '5 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Stratum supports three authentication paths: interactive sessions for the dashboard, API keys for server-to-server calls, and OAuth for connecting external ad platforms. All three are scoped to a single tenant.',
+      },
+      { type: 'heading', text: 'API keys' },
+      {
+        type: 'paragraph',
+        text: 'Generate a key under Settings → API. Keys are shown once at creation, carry workspace-scoped permissions, and should be stored as a secret in your backend — never in frontend code or a committed file.',
+      },
+      {
+        type: 'code',
+        language: 'bash',
+        code: 'curl https://api.stratumai.app/api/v1/signals \\\n  -H "Authorization: Bearer $STRATUM_API_KEY"',
+      },
+      { type: 'heading', text: 'Dashboard sessions and MFA' },
+      {
+        type: 'paragraph',
+        text: 'Interactive logins issue a short-lived JWT. The token carries your user and tenant identity and permissions, but never raw PII. We strongly recommend enabling TOTP-based multi-factor authentication for every user with automation privileges.',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'JWTs expire quickly and are refreshed transparently in the dashboard. For programmatic access, prefer an API key over scripting a login.',
+      },
+      { type: 'heading', text: 'OAuth for platform connections' },
+      {
+        type: 'paragraph',
+        text: 'When you connect Meta, Google, TikTok, or Snapchat, Stratum runs the provider OAuth flow and stores only an encrypted refresh token. We request the minimum scopes needed to read performance data and manage the entities your automations control.',
+      },
+      {
+        type: 'list',
+        items: [
+          'Revoke a connection any time from Integrations — the stored token is deleted immediately.',
+          'Rotating an API key invalidates the old one on the next request.',
+          'All authentication events are written to the tenant audit log.',
+        ],
+      },
+    ],
+  },
+  {
+    slug: 'first-campaign',
+    category: 'Getting Started',
+    title: 'Your First Campaign',
+    description:
+      'Build, arm, and graduate a trust-gated automation from advisory to autopilot.',
+    readTime: '8 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'This walkthrough takes a real optimization — shifting budget toward your best-performing campaigns — and runs it through the trust gate so it only acts when your data is reliable.',
+      },
+      { type: 'heading', text: '1. Define the objective' },
+      {
+        type: 'paragraph',
+        text: 'Pick a measurable goal such as maintaining ROAS above a target while spending the day’s budget evenly. Stratum frames every automation around a metric it can verify from signal data.',
+      },
+      { type: 'heading', text: '2. Choose an enforcement mode' },
+      {
+        type: 'list',
+        items: [
+          'Advisory — recommends the action, executes nothing. Start here.',
+          'Soft-Block — executes when healthy, holds and alerts when degraded.',
+          'Hard-Block — executes only when healthy; anything below threshold requires manual approval.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        title: 'Build trust before you delegate',
+        text: 'Run in Advisory for a few days and compare Stratum’s recommendations against your own decisions. Graduate to Soft-Block once the recommendations consistently match your intent.',
+      },
+      { type: 'heading', text: '3. Set the trust gate' },
+      {
+        type: 'paragraph',
+        text: 'The trust gate checks signal health before each execution. With the default healthy threshold of 70, the automation runs normally when green, holds when degraded, and blocks when unhealthy — so a tracking outage can never trigger a bad budget move.',
+      },
+      { type: 'heading', text: '4. Review the audit trail' },
+      {
+        type: 'paragraph',
+        text: 'Every gate decision and every executed action is logged with the signal health snapshot that justified it. Open the automation’s history to see exactly why it ran, held, or blocked.',
+      },
+      { type: 'heading', text: '5. Graduate to autopilot' },
+      {
+        type: 'paragraph',
+        text: 'When you are confident, switch to Soft-Block or Hard-Block. The automation now runs on its own while the trust gate keeps it honest — acting on healthy data and standing down the moment your signals degrade.',
+      },
+    ],
+  },
+];

--- a/frontend/src/views/pages/resources/docs/content/integrations.ts
+++ b/frontend/src/views/pages/resources/docs/content/integrations.ts
@@ -1,0 +1,214 @@
+import type { DocArticle } from '../types';
+
+export const integrationsArticles: DocArticle[] = [
+  {
+    slug: 'integrations/meta',
+    category: 'Integrations',
+    title: 'Meta Ads',
+    description:
+      'Connect Meta Marketing API to read performance, control campaigns, and raise match quality with CAPI and Custom Audiences.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'The Meta integration connects your Business and ad accounts to Stratum through the Meta Marketing API. Once connected, signal collectors pull campaign performance and event deliveries, a per-platform health calculation feeds Signal Health, and your trust-gated automations can manage budgets, bids, and campaign status.',
+      },
+      { type: 'heading', text: 'What you can do' },
+      {
+        type: 'list',
+        items: [
+          'Read campaign, ad set, and ad performance across your connected ad accounts.',
+          'Let automations adjust budgets, bids, and pause or enable entities — always behind the trust gate.',
+          'Send server-side conversions through the Conversions API (CAPI) to raise Event Match Quality.',
+          'Activate CDP segments as Meta Custom Audiences for targeting and suppression.',
+        ],
+      },
+      { type: 'heading', text: 'Connect via OAuth' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Open Integrations and choose Meta.',
+          'Complete Meta’s consent flow — Stratum never sees your password and stores only an encrypted refresh token.',
+          'Select the Business and ad accounts you want Stratum to read and manage.',
+          'Wait a few minutes for collectors to begin pulling metrics and events.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Stratum requests the minimum scopes needed to read ads performance and manage the entities your automations control. Meta access tokens are short-lived; Stratum refreshes them automatically from the stored encrypted token, so you do not have to reconnect routinely.',
+      },
+      { type: 'heading', text: 'Conversions API and Custom Audiences' },
+      {
+        type: 'paragraph',
+        text: 'CAPI sends conversion events server-side, bypassing browser and cookie limitations that suppress client-side pixels. Combined with the web tag, it keeps Event Match Quality high and signal health resilient. CDP segments push to Meta Custom Audiences for activation without ever exposing raw identifiers.',
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Least scope, hashed PII',
+        text: 'Stratum requests only the scopes it needs, and email and phone identifiers are lower-cased, trimmed, and SHA-256 hashed before they are sent to Meta for matching. Raw PII is never required for CAPI or audience sync.',
+      },
+      { type: 'heading', text: 'Troubleshooting' },
+      {
+        type: 'paragraph',
+        text: 'If API health drops or actions start failing, the most common cause is a token that lost permissions on Meta’s side. Reconnect from Integrations to re-run consent. Revoking a connection deletes the stored token immediately, so a clean reconnect is always safe.',
+      },
+    ],
+  },
+  {
+    slug: 'integrations/google',
+    category: 'Integrations',
+    title: 'Google Ads',
+    description:
+      'Connect Google Ads API to read Search, Display, and YouTube performance, import conversions, and sync Customer Match.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'The Google integration connects your Google Ads accounts through the Google Ads API. Stratum reads performance across Search, Display, and YouTube, lets automations manage your campaigns behind the trust gate, and activates CDP segments as Customer Match audiences.',
+      },
+      { type: 'heading', text: 'What you can do' },
+      {
+        type: 'list',
+        items: [
+          'Read campaign performance across Search, Display, and YouTube inventory.',
+          'Let automations adjust budgets, bidding strategy, and campaign status under trust-gate control.',
+          'Import server-side conversions so Google optimizes toward verified outcomes.',
+          'Activate CDP segments as Google Customer Match audiences.',
+        ],
+      },
+      { type: 'heading', text: 'Connect via OAuth' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Open Integrations and choose Google.',
+          'Complete Google’s OAuth consent flow — Stratum stores only an encrypted refresh token, never your password.',
+          'Select the Google Ads accounts Stratum should read and manage.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'The Google Ads API is accessed through a developer token alongside your OAuth grant. Stratum manages the developer token centrally, so you only complete the OAuth consent — there is nothing to paste. We request the minimum scopes needed to read performance data and manage the entities automations control.',
+      },
+      { type: 'heading', text: 'Conversion import and Customer Match' },
+      {
+        type: 'paragraph',
+        text: 'Conversion import sends server-side conversions into Google Ads so bidding optimizes against outcomes that survive browser restrictions — this lifts Event Match Quality the same way CAPI does on other platforms. Customer Match takes CDP segments and matches them against Google’s user base for targeting and exclusions.',
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Hashed identifiers only',
+        text: 'Customer Match and conversion import use SHA-256 hashed emails and phone numbers. Identifiers are normalized and hashed before they leave your environment, so raw PII is never shared with Google.',
+      },
+      { type: 'heading', text: 'Troubleshooting' },
+      {
+        type: 'paragraph',
+        text: 'If conversions stop importing or accounts disappear from the picker, check that the connected Google user still has access to the manager and child accounts. Reconnect from Integrations to refresh consent; the previous token is deleted the moment you revoke.',
+      },
+    ],
+  },
+  {
+    slug: 'integrations/tiktok',
+    category: 'Integrations',
+    title: 'TikTok Ads',
+    description:
+      'Connect TikTok Ads API to read performance, send Events API conversions, and sync DMP Custom Audiences.',
+    readTime: '5 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'The TikTok integration connects your advertiser accounts through the TikTok Ads API. Stratum reads campaign performance, manages entities behind the trust gate, sends server-side conversions through the Events API, and activates CDP segments as TikTok Custom Audiences.',
+      },
+      { type: 'heading', text: 'What you can do' },
+      {
+        type: 'list',
+        items: [
+          'Read campaign, ad group, and ad performance from connected advertiser accounts.',
+          'Let automations adjust budgets, bids, and status under trust-gate control.',
+          'Send conversions server-side via the TikTok Events API to raise Event Match Quality.',
+          'Activate CDP segments as TikTok DMP Custom Audiences.',
+        ],
+      },
+      { type: 'heading', text: 'Connect via OAuth' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Open Integrations and choose TikTok.',
+          'Complete TikTok’s OAuth consent flow — Stratum stores only an encrypted refresh token.',
+          'Select the advertiser accounts Stratum should read and manage.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'As with every platform, Stratum requests the minimum scopes needed to read performance data and manage the entities your automations control. The connection is registered in the integration registry, and collectors begin pulling metrics and events within a few minutes.',
+      },
+      { type: 'heading', text: 'Events API and Custom Audiences' },
+      {
+        type: 'paragraph',
+        text: 'The TikTok Events API delivers conversions server-side, bypassing browser limits to keep match quality and signal health strong. DMP Custom Audiences let you push CDP segments to TikTok using SHA-256 hashed identifiers — raw PII is never sent.',
+      },
+      { type: 'heading', text: 'Troubleshooting' },
+      {
+        type: 'paragraph',
+        text: 'If events stop matching or actions fail, confirm the connected user still has advertiser access and reconnect from Integrations. Revoking deletes the stored token immediately, so reconnecting always starts from a clean grant.',
+      },
+    ],
+  },
+  {
+    slug: 'integrations/crm',
+    category: 'Integrations',
+    title: 'CRM Systems',
+    description:
+      'Sync HubSpot and Zoho contacts and companies into the CDP, and wire Slack and WhatsApp for notifications.',
+    readTime: '5 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Beyond ad platforms, Stratum integrates with CRM and messaging systems. HubSpot and Zoho sync contacts and companies into the Customer Data Platform for enrichment and segmentation, while Slack and WhatsApp Business carry notifications out to your team and customers.',
+      },
+      { type: 'heading', text: 'HubSpot and Zoho' },
+      {
+        type: 'paragraph',
+        text: 'Connecting a CRM lets Stratum mirror your contact and company records into the CDP, where they merge with behavioral events to build unified profiles. Those profiles power computed traits, lifecycle stages, and the segments you later activate as ad-platform audiences.',
+      },
+      {
+        type: 'list',
+        items: [
+          'Contacts sync as CDP profiles, joined to existing identities by email.',
+          'Companies sync as account records for B2B segmentation.',
+          'Sync runs continuously after the initial backfill, keeping profiles current without manual exports.',
+        ],
+      },
+      { type: 'heading', text: 'Connect via OAuth' },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Open Integrations and choose HubSpot or Zoho.',
+          'Complete the provider’s OAuth consent flow — Stratum stores only an encrypted refresh token.',
+          'Pick the objects to sync; the initial backfill begins immediately.',
+        ],
+      },
+      { type: 'heading', text: 'Slack and WhatsApp' },
+      {
+        type: 'paragraph',
+        text: 'Slack delivers alerts and scheduled reports to a channel of your choice — trust-gate holds, signal-health drops, and autopilot decisions all surface where your team already works. WhatsApp Business adds a customer messaging channel for transactional and lifecycle notifications.',
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Least scope, hashed PII',
+        text: 'CRM connections request only the scopes needed to read and sync the selected objects. When CRM profiles feed audience activation, their email and phone identifiers are SHA-256 hashed before any platform sync — raw PII never leaves the CDP unhashed.',
+      },
+      { type: 'heading', text: 'Troubleshooting' },
+      {
+        type: 'paragraph',
+        text: 'If sync stalls, the connected CRM user’s permissions are the first thing to check. Reconnect from Integrations to refresh consent; revoking deletes the stored token immediately and stops all further syncing.',
+      },
+    ],
+  },
+];

--- a/frontend/src/views/pages/resources/docs/content/trustEngine.ts
+++ b/frontend/src/views/pages/resources/docs/content/trustEngine.ts
@@ -1,0 +1,234 @@
+import type { DocArticle } from '../types';
+
+export const trustEngineArticles: DocArticle[] = [
+  {
+    slug: 'signal-health',
+    category: 'Trust Engine',
+    title: 'Signal Health',
+    description:
+      'The composite 0–100 score that tells you how reliable your data is right now — and whether autopilot is allowed to run.',
+    readTime: '7 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Signal Health is the heartbeat of the Trust Engine. It is a single composite score from 0 to 100 that summarizes how reliable your incoming data is at this moment. Every automation in Stratum reads this score before it acts, so understanding what moves it is the key to understanding why autopilot runs, holds, or stands down.',
+      },
+      {
+        type: 'paragraph',
+        text: 'The score is computed continuously. As collectors pull metrics, events, and webhook deliveries from your connected platforms, the Health Calculator re-evaluates the blend in near real time — you never wait for a nightly batch to learn that something degraded.',
+      },
+      { type: 'heading', text: 'The five weighted components' },
+      {
+        type: 'paragraph',
+        text: 'Signal Health is a weighted average of five inputs. Each measures a different failure mode, so a problem in any one of them pulls the composite down proportionally to its weight:',
+      },
+      {
+        type: 'list',
+        items: [
+          'Event Match Quality (EMQ) — 35%: how well your tracked events match platform data, which directly drives attribution accuracy.',
+          'API Health — 25%: the responsiveness and error rate of the platform APIs feeding your account.',
+          'Event Loss — 20%: the share of expected events that never arrived or were dropped in transit.',
+          'Platform Stability — 10%: how steady the upstream platform has been, independent of your own integration.',
+          'Data Quality — 10%: the completeness and consistency of the fields on the events you do receive.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        title: 'Why EMQ dominates',
+        text: 'EMQ carries the heaviest weight because poor match quality quietly corrupts every downstream decision — attribution, ROAS, and the budget moves autopilot makes from them. Fix EMQ first when health drops.',
+      },
+      { type: 'heading', text: 'How the bands map to action' },
+      {
+        type: 'paragraph',
+        text: 'The raw score is meaningless without the bands that translate it into a decision. Stratum uses three:',
+      },
+      {
+        type: 'list',
+        items: [
+          '70–100 Healthy (green) — signals are reliable and autopilot is enabled.',
+          '40–69 Degraded (yellow) — quality is questionable, so Stratum alerts and holds rather than acts.',
+          '0–39 Unhealthy (red) — data cannot be trusted and manual intervention is required.',
+        ],
+      },
+      { type: 'heading', text: 'Reading a drop' },
+      {
+        type: 'paragraph',
+        text: 'When the composite falls, open the breakdown and look at which component moved. A sudden EMQ collapse usually means an identifier stopped flowing — a broken tag, an expired token, or a CAPI outage. A spike in event loss points at delivery problems, while an API health dip is often the platform itself. Because the weights are fixed and visible, you can always reconstruct exactly why the number changed.',
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        text: 'Signal Health is not a vanity metric — it is the input the Trust Gate evaluates before every automation. Keep it green and autopilot stays armed.',
+      },
+    ],
+  },
+  {
+    slug: 'trust-gates',
+    category: 'Trust Engine',
+    title: 'Trust Gates',
+    description:
+      'The decision checkpoint that evaluates signal health before any automation executes — PASS, HOLD, or BLOCK.',
+    readTime: '6 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'A Trust Gate is the checkpoint that sits between an automation and the action it wants to take. Before any execution, the gate reads the current Signal Health score and returns one of three outcomes. Nothing reaches your ad platforms without passing through it.',
+      },
+      { type: 'heading', text: 'The PASS / HOLD / BLOCK model' },
+      {
+        type: 'list',
+        items: [
+          'PASS — signal health meets the threshold, so the automation proceeds and executes.',
+          'HOLD — health is degraded; the gate alerts you but executes nothing.',
+          'BLOCK — health is unhealthy; the action is stopped and manual approval is required.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'The gate is re-evaluated on every execution, not once at setup. An automation that passed this morning can hold this afternoon if EMQ slips — the decision always reflects the data as it is right now.',
+      },
+      { type: 'heading', text: 'Where the gate sits' },
+      {
+        type: 'paragraph',
+        text: 'In the Trust Engine flow, signals move from collectors to the Health Calculator, which produces the composite score. The Trust Gate consumes that score and decides whether the Automation Executor is allowed to run:',
+      },
+      {
+        type: 'code',
+        language: 'text',
+        code: 'Signal Collectors → Health Calculator → Trust Gate → Automation Executor\n                                            │\n                                  PASS ──────┤\n                                  HOLD ──────┤ (alert only)\n                                  BLOCK ─────┘ (manual approval)',
+      },
+      { type: 'heading', text: 'A worked example' },
+      {
+        type: 'paragraph',
+        text: 'Suppose a tracking outage takes your CAPI endpoint offline for twenty minutes. Events stop matching, EMQ falls, and because EMQ carries 35% of the weight the composite drops from 82 into the degraded band at 58. At that moment an autopilot rule wants to shift $400 of budget toward a campaign whose ROAS just spiked.',
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'The gate protects you here',
+        text: 'That ROAS spike is an artifact of the outage, not real performance. Because health is 58, the gate returns HOLD: it alerts you and refuses to move the budget. When events resume and health climbs back above 70, the gate passes again — and only then does autopilot reconsider the move on trustworthy data.',
+      },
+      { type: 'heading', text: 'The audit trail' },
+      {
+        type: 'paragraph',
+        text: 'Every gate decision is written to the tenant audit log alongside the signal-health snapshot that justified it. Open an automation’s history and you can see, for each evaluation, the score at that instant, the outcome, and the action that was taken or withheld. Nothing the Trust Engine does is a black box.',
+      },
+    ],
+  },
+  {
+    slug: 'autopilot',
+    category: 'Trust Engine',
+    title: 'Autopilot Rules',
+    description:
+      'How automations act on healthy data — enforcement modes, the actions they take, and the safety guarantees behind them.',
+    readTime: '7 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Autopilot is what executes once a Trust Gate passes. An autopilot rule pairs an objective with an enforcement mode, then lets the Trust Engine decide on every cycle whether the data is good enough to act. The result is automation you can leave running without fear of it acting on bad signals.',
+      },
+      { type: 'heading', text: 'What autopilot can do' },
+      {
+        type: 'list',
+        items: [
+          'Adjust campaign budgets up or down.',
+          'Modify bidding strategies.',
+          'Pause or enable campaigns.',
+          'Scale spend based on measured performance.',
+        ],
+      },
+      { type: 'heading', text: 'Enforcement modes' },
+      {
+        type: 'paragraph',
+        text: 'Enforcement mode controls how strictly the gate is applied to a given rule. There are three:',
+      },
+      {
+        type: 'list',
+        items: [
+          'Advisory — Stratum recommends the action but executes nothing. Use it to evaluate the engine’s judgment.',
+          'Soft-Block — executes when health is healthy; holds and alerts when degraded.',
+          'Hard-Block — executes only when healthy; anything below threshold requires manual approval.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        title: 'Advisory is a real mode, not a dry run',
+        text: 'In Advisory the engine evaluates the gate and surfaces exactly the action it would take, with the score behind it — so you can audit its reasoning before handing over control.',
+      },
+      { type: 'heading', text: 'Graduating a rule' },
+      {
+        type: 'paragraph',
+        text: 'The recommended path is to graduate trust gradually rather than arming a rule cold:',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Start in Advisory and compare the engine’s recommendations against your own decisions for a few days.',
+          'Move to Soft-Block once the recommendations consistently match your intent — the rule now acts on healthy data and stands down when signals degrade.',
+          'Promote to Hard-Block for your most sensitive spend, where you want zero execution unless the data is unambiguously healthy.',
+        ],
+      },
+      { type: 'heading', text: 'Safety guarantees' },
+      {
+        type: 'paragraph',
+        text: 'Two invariants hold regardless of mode. First, autopilot never auto-executes when signal health is below the healthy threshold — degraded data can only ever produce a hold or a manual request, never an automatic action. Second, every executed action and every gate decision is written to the audit log with the health snapshot that justified it, so the full chain from signal to action is always reconstructable.',
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        text: 'Trust-gated autopilot means the worst case for a degraded signal is an alert and a held action — not a bad budget move executed on broken data.',
+      },
+    ],
+  },
+  {
+    slug: 'thresholds',
+    category: 'Trust Engine',
+    title: 'Thresholds',
+    description:
+      'The healthy and degraded cutoffs, how to tune them per tenant, and when tighter or looser limits make sense.',
+    readTime: '5 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Thresholds are the numbers that turn a Signal Health score into a gate decision. Two cutoffs define the three bands, and both are configurable per tenant so you can match the engine’s caution to your own risk tolerance.',
+      },
+      { type: 'heading', text: 'The defaults' },
+      {
+        type: 'list',
+        items: [
+          'HEALTHY_THRESHOLD = 70 — at or above this, signals are healthy and autopilot is eligible.',
+          'DEGRADED_THRESHOLD = 40 — between 40 and 69 the gate holds; below 40 it blocks.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'The hard floor',
+        text: 'Stratum never auto-executes when signal_health is below 70. You can raise the healthy threshold, but autopilot will not act on degraded data regardless of how a rule is configured.',
+      },
+      { type: 'heading', text: 'Configuring per tenant' },
+      {
+        type: 'paragraph',
+        text: 'Thresholds live in the tenant’s TrustGateConfig. Adjusting them shifts where the bands fall without touching any individual automation — every gate in the workspace reads the same config:',
+      },
+      {
+        type: 'code',
+        language: 'json',
+        code: '{\n  "trust_gate_config": {\n    "healthy_threshold": 70,\n    "degraded_threshold": 40,\n    "enforcement_mode": "soft_block"\n  }\n}',
+      },
+      { type: 'heading', text: 'When to tighten or loosen' },
+      {
+        type: 'paragraph',
+        text: 'Raise the healthy threshold — say to 80 — when you manage high-stakes spend and want autopilot to act only on pristine data; the trade-off is more holds during normal noise. Lower it cautiously when your signals are inherently noisier and you would rather act on imperfect data than stall, accepting a higher chance of acting on a transient dip.',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'Change thresholds in small steps and watch the audit log. If a new cutoff produces a wave of holds or executions, you will see exactly which scores crossed the line and can dial it back.',
+      },
+    ],
+  },
+];

--- a/frontend/src/views/pages/resources/docs/content/tutorials.ts
+++ b/frontend/src/views/pages/resources/docs/content/tutorials.ts
@@ -1,0 +1,273 @@
+import type { DocArticle } from '../types';
+
+export const tutorialsArticles: DocArticle[] = [
+  {
+    slug: 'tutorials/videos',
+    category: 'Tutorials',
+    title: 'Video Tutorials',
+    description:
+      'A short catalog of guided video walkthroughs for the core Stratum workflows.',
+    readTime: '3 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'These walkthroughs cover the workflows most people reach for in their first week. Each is task-focused and recorded against the live product, so the screens match what you see. Pick the one closest to what you are trying to do.',
+      },
+      { type: 'heading', text: 'Getting connected' },
+      {
+        type: 'list',
+        items: [
+          'Connect Meta in 3 minutes — run the OAuth consent flow, pick ad accounts, and confirm the signal collectors start pulling data. (3:12)',
+          'Install the web tag and CAPI — add the snippet, send your first server event, and watch Event Match Quality climb. (4:40)',
+        ],
+      },
+      { type: 'heading', text: 'Trust and automation' },
+      {
+        type: 'list',
+        items: [
+          'Read Signal Health — what the 0–100 score means and how EMQ, API health, event loss, platform stability, and data quality roll up. (3:55)',
+          'Build your first Trust Gate — set a healthy threshold, choose an enforcement mode, and arm an automation in Advisory. (6:20)',
+          'Graduate from Advisory to autopilot — review the audit trail and switch a proven automation to Soft-Block. (4:05)',
+        ],
+      },
+      { type: 'heading', text: 'CDP and audiences' },
+      {
+        type: 'list',
+        items: [
+          'Create a predictive segment — define a churn-risk audience from RFM and lifecycle traits. (5:30)',
+          'Sync an audience to a platform — push a segment to Meta or Google with SHA-256 hashed identifiers. (3:48)',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'Each video has a matching written guide elsewhere in these docs. If you prefer to read, follow Quick Start, First Campaign, and the CDP articles for the same material at your own pace.',
+      },
+    ],
+  },
+  {
+    slug: 'tutorials/use-cases',
+    category: 'Tutorials',
+    title: 'Use Cases',
+    description:
+      'Four end-to-end scenarios showing how trust-gated autopilot and the CDP solve real revenue problems.',
+    readTime: '8 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'The patterns below are the ones teams reach for most. Each gives you the goal, the Stratum setup, and the outcome you should expect. They assume at least one connected platform and signal health that has settled.',
+      },
+      { type: 'heading', text: 'Protect ROAS during a tracking outage' },
+      {
+        type: 'paragraph',
+        text: 'Goal: stop automations from making bad budget decisions when your data goes dark — a pixel break, a CAPI gateway error, or a platform API incident.',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Run your budget and bid automations in Soft-Block or Hard-Block enforcement.',
+          'Leave the trust gate at the default healthy threshold of 70.',
+          'When event loss spikes or API health drops, signal health falls into the degraded band (40–69) and the gate returns HOLD instead of executing.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Outcome: the moment your signals degrade, autopilot stands down and alerts you rather than scaling spend on numbers it cannot trust. When health recovers above 70 the gate returns PASS and execution resumes automatically.',
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        title: 'Why this works',
+        text: 'The gate evaluates signal health before every execution, so a transient outage can never silently corrupt a budget move. The held action and its health snapshot are written to the audit log.',
+      },
+      { type: 'heading', text: 'Scale spend on a healthy winner' },
+      {
+        type: 'paragraph',
+        text: 'Goal: push more budget toward a campaign that is beating its ROAS target, but only while the underlying data is reliable.',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Create a pacing automation that increases budget when ROAS stays above your target across the measurement window.',
+          'Start in Advisory and compare the recommendations to your own calls for a few days.',
+          'Graduate to Soft-Block once the recommendations consistently match your intent.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Outcome: Stratum compounds spend into the winner during healthy periods and pauses scaling whenever signal health dips — capturing upside without overcommitting on noisy data.',
+      },
+      { type: 'heading', text: 'Win back At-Risk customers' },
+      {
+        type: 'paragraph',
+        text: 'Goal: re-engage customers whose behavior signals declining engagement before they churn.',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Build a predictive segment in the CDP targeting the At-Risk lifecycle stage, refined by RFM — low recency, previously high frequency or monetary value.',
+          'Sync the segment to Meta and Google as a custom audience; identifiers are SHA-256 hashed before they leave Stratum.',
+          'Run a win-back campaign against that audience and track recovered revenue with data-driven attribution.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Outcome: a tightly-targeted, privacy-safe audience that focuses spend on customers worth saving, with attribution showing what the win-back actually recovered.',
+      },
+      { type: 'heading', text: 'Cut CAC by reallocating budget' },
+      {
+        type: 'paragraph',
+        text: 'Goal: lower Customer Acquisition Cost by moving budget away from inefficient sources and toward those acquiring customers more cheaply.',
+      },
+      {
+        type: 'list',
+        ordered: true,
+        items: [
+          'Use attribution — last-click for a quick read, data-driven (DDA) for a fuller picture — to compare CAC and MER across platforms.',
+          'Configure an automation that shifts budget toward the lower-CAC sources within your guardrails.',
+          'Keep the trust gate active so reallocation only fires on healthy signals.',
+        ],
+      },
+      {
+        type: 'paragraph',
+        text: 'Outcome: blended CAC trends down while MER holds or improves, and every reallocation is gated on trustworthy data and recorded in the audit trail.',
+      },
+    ],
+  },
+  {
+    slug: 'tutorials/best-practices',
+    category: 'Tutorials',
+    title: 'Best Practices',
+    description:
+      'Field-tested guidance for running trust-gated autopilot, the CDP, and integrations safely.',
+    readTime: '9 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'These practices come from how the platform is meant to be operated. None of them are mandatory, but following them keeps automations trustworthy, audiences clean, and your tenant secure.',
+      },
+      { type: 'heading', text: 'Roll out automations gradually' },
+      {
+        type: 'list',
+        items: [
+          'Start every new automation in Advisory — it recommends the action and executes nothing, so you can judge the recommendations against reality.',
+          'Move to Soft-Block once the recommendations consistently match your intent; it executes when healthy and holds with an alert when degraded.',
+          'Reserve Hard-Block for high-stakes actions where anything below threshold should require manual approval.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'success',
+        title: 'Build trust before you delegate',
+        text: 'A few days in Advisory is the cheapest insurance you can buy. You learn the system’s judgment with zero risk, then graduate with confidence.',
+      },
+      { type: 'heading', text: 'Set thresholds to your risk tolerance' },
+      {
+        type: 'paragraph',
+        text: 'The defaults — healthy at 70, degraded 40–69, unhealthy below 40 — are a sensible starting point, but thresholds are configurable per tenant. Raise the healthy threshold for sensitive accounts so the gate is stricter; loosen it only when you genuinely accept more noise. Never hardcode thresholds outside the config.',
+      },
+      { type: 'heading', text: 'Raise EMQ with server events' },
+      {
+        type: 'list',
+        items: [
+          'Send conversions through the Conversions API (CAPI) as well as the browser tag — server events are immune to ad blockers and cookie limits.',
+          'Include as many matchable identifiers as you can (email, phone, order id), since Event Match Quality is 35% of signal health.',
+          'Lower-case, trim, and SHA-256 hash PII before it leaves your servers.',
+        ],
+      },
+      { type: 'heading', text: 'Segment before you sync' },
+      {
+        type: 'paragraph',
+        text: 'Define and inspect a segment in the CDP — behavioral, demographic, or predictive — before pushing it anywhere. Confirm the profile count and lifecycle mix look right, then sync to Meta, Google, TikTok, or Snapchat. Audience matching uses hashed identifiers, so raw PII never reaches the platform.',
+      },
+      { type: 'heading', text: 'Monitor signal health continuously' },
+      {
+        type: 'list',
+        items: [
+          'Treat the Overview as a triage queue — it surfaces what needs attention first.',
+          'Investigate a sustained drop into the degraded band before it blocks; check API health and event loss as leading indicators.',
+          'Remember the weights: EMQ 35%, API Health 25%, Event Loss 20%, Platform Stability 10%, Data Quality 10%.',
+        ],
+      },
+      { type: 'heading', text: 'Use audit logs as your source of truth' },
+      {
+        type: 'paragraph',
+        text: 'Every gate decision and executed action is logged with the signal health snapshot that justified it. When an automation ran, held, or blocked, the audit trail tells you exactly why — use it for post-incident reviews and stakeholder reporting rather than guessing.',
+      },
+      { type: 'heading', text: 'Lock down access' },
+      {
+        type: 'list',
+        items: [
+          'Grant least-privilege OAuth scopes — only what an integration needs to read performance data and manage the entities it controls.',
+          'Enable TOTP-based MFA for every user with automation privileges.',
+          'Store API keys as backend secrets, never in frontend code or committed files, and rotate them periodically.',
+          'Keep PII out of tokens and logs; rely on encrypted database fields and hashed identifiers.',
+        ],
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'A common pitfall',
+        text: 'Do not disable the trust gate for a "quick fix." Bypassing it is exactly how a tracking outage turns into a bad budget move that the audit log will later attribute to a manual override.',
+      },
+    ],
+  },
+  {
+    slug: 'tutorials/troubleshooting',
+    category: 'Tutorials',
+    title: 'Troubleshooting',
+    description:
+      'Diagnose and fix the most common issues with signals, gates, integrations, and webhooks.',
+    readTime: '7 min',
+    blocks: [
+      {
+        type: 'paragraph',
+        text: 'Most issues trace back to a handful of root causes. Each section below gives the likely cause and the fix. When in doubt, start at the Overview and the audit log — they usually point straight at the problem.',
+      },
+      { type: 'subheading', text: 'Signal health is stuck Degraded or Blocked' },
+      {
+        type: 'paragraph',
+        text: 'Cause: one or more components are dragging the composite score down — most often falling API health or rising event loss. Fix: open Signal Health and inspect the breakdown. A degraded platform API or a CAPI gateway returning errors will surface here; resolve the upstream issue and the score recovers on its own once data flows cleanly again.',
+      },
+      { type: 'subheading', text: 'An automation is not executing' },
+      {
+        type: 'paragraph',
+        text: 'Cause: the trust gate is returning HOLD or BLOCK, or the automation is in the wrong enforcement mode. Fix: check the automation’s latest gate decision in the audit log. If health is below your healthy threshold the gate is correctly holding — wait for recovery or investigate the signal drop. If you expected execution while degraded, confirm you are not in Advisory (which never executes) and review your enforcement mode.',
+      },
+      {
+        type: 'callout',
+        tone: 'info',
+        text: 'Advisory mode is working as designed when it does not execute — it only ever recommends. Move to Soft-Block to allow execution on healthy signals.',
+      },
+      { type: 'subheading', text: 'Low EMQ or audience match rate' },
+      {
+        type: 'paragraph',
+        text: 'Cause: events are missing identifiers, or you are relying on browser events alone. Fix: send conversions through CAPI in addition to the web tag, and include every matchable identifier you have (email, phone, order id). Make sure PII is lower-cased, trimmed, and SHA-256 hashed in the format the platform expects — a formatting mismatch silently tanks match rates.',
+      },
+      { type: 'subheading', text: 'OAuth token expired or revoked' },
+      {
+        type: 'paragraph',
+        text: 'Cause: the platform refresh token was revoked, or the connecting user lost access on the platform side. Fix: reconnect the integration to run a fresh OAuth consent flow — Stratum stores only the new encrypted refresh token. Signal collection resumes once the connection is healthy again.',
+      },
+      { type: 'subheading', text: 'Hitting 429 rate limits' },
+      {
+        type: 'paragraph',
+        text: 'Cause: too many API requests in a short window against the per-tenant Redis rate limit. Fix: back off and retry with exponential delay, honor any Retry-After header, and batch writes instead of sending one request per record. If a job consistently saturates the limit, spread it over a longer window.',
+      },
+      { type: 'subheading', text: 'A webhook is not being received' },
+      {
+        type: 'paragraph',
+        text: 'Cause: a wrong endpoint URL, a failed signature verification, or a non-2xx response causing the sender to treat delivery as failed. Fix: confirm the endpoint is reachable and returns 2xx quickly, verify the signature using the shared secret with a constant-time comparison, and check the delivery log for the rejection reason before assuming the event was never sent.',
+      },
+      {
+        type: 'callout',
+        tone: 'warning',
+        title: 'Still stuck?',
+        text: 'Capture the relevant audit-log entry and signal health snapshot before escalating. They contain the exact decision, timestamp, and component scores support needs to reproduce the issue.',
+      },
+    ],
+  },
+];

--- a/frontend/src/views/pages/resources/docs/registry.ts
+++ b/frontend/src/views/pages/resources/docs/registry.ts
@@ -1,0 +1,118 @@
+/**
+ * Documentation registry — single source of truth for both the `/docs`
+ * portal navigation and the dynamic `/docs/*` article pages.
+ *
+ * `docsNav` drives the category cards on the portal; `docArticles` maps a
+ * slug to its authored content. The two are kept in sync here: every
+ * internal nav link (one starting `/docs/`) must resolve to an article.
+ */
+
+import {
+  AcademicCapIcon,
+  CloudIcon,
+  CodeBracketIcon,
+  CpuChipIcon,
+  PlayIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline';
+import type { DocArticle, DocNavCategory } from './types';
+
+import { gettingStartedArticles } from './content/gettingStarted';
+import { apiReferenceArticles } from './content/apiReference';
+import { trustEngineArticles } from './content/trustEngine';
+import { cdpArticles } from './content/cdp';
+import { integrationsArticles } from './content/integrations';
+import { tutorialsArticles } from './content/tutorials';
+
+export const docsNav: DocNavCategory[] = [
+  {
+    title: 'Getting Started',
+    description: 'Quick start guides to get you up and running',
+    icon: PlayIcon,
+    links: [
+      { name: 'Quick Start Guide', href: '/docs/quickstart' },
+      { name: 'Installation', href: '/docs/installation' },
+      { name: 'Authentication', href: '/docs/auth' },
+      { name: 'First Campaign', href: '/docs/first-campaign' },
+    ],
+  },
+  {
+    title: 'API Reference',
+    description: 'Complete API documentation with examples',
+    icon: CodeBracketIcon,
+    links: [
+      { name: 'REST API', href: '/api-docs' },
+      { name: 'Webhooks', href: '/docs/webhooks' },
+      { name: 'SDKs', href: '/docs/sdks' },
+      { name: 'Rate Limits', href: '/docs/rate-limits' },
+    ],
+  },
+  {
+    title: 'Trust Engine',
+    description: 'Learn about our trust-gated automation',
+    icon: ShieldCheckIcon,
+    links: [
+      { name: 'Signal Health', href: '/docs/signal-health' },
+      { name: 'Trust Gates', href: '/docs/trust-gates' },
+      { name: 'Autopilot Rules', href: '/docs/autopilot' },
+      { name: 'Thresholds', href: '/docs/thresholds' },
+    ],
+  },
+  {
+    title: 'CDP',
+    description: 'Customer Data Platform documentation',
+    icon: CpuChipIcon,
+    links: [
+      { name: 'Profiles', href: '/docs/cdp/profiles' },
+      { name: 'Segments', href: '/docs/cdp/segments' },
+      { name: 'Identity Resolution', href: '/docs/cdp/identity' },
+      { name: 'Audience Sync', href: '/docs/cdp/audience-sync' },
+    ],
+  },
+  {
+    title: 'Integrations',
+    description: 'Connect with ad platforms and tools',
+    icon: CloudIcon,
+    links: [
+      { name: 'Meta Ads', href: '/docs/integrations/meta' },
+      { name: 'Google Ads', href: '/docs/integrations/google' },
+      { name: 'TikTok Ads', href: '/docs/integrations/tiktok' },
+      { name: 'CRM Systems', href: '/docs/integrations/crm' },
+    ],
+  },
+  {
+    title: 'Tutorials',
+    description: 'Step-by-step guides and best practices',
+    icon: AcademicCapIcon,
+    links: [
+      { name: 'Video Tutorials', href: '/docs/tutorials/videos' },
+      { name: 'Use Cases', href: '/docs/tutorials/use-cases' },
+      { name: 'Best Practices', href: '/docs/tutorials/best-practices' },
+      { name: 'Troubleshooting', href: '/docs/tutorials/troubleshooting' },
+    ],
+  },
+];
+
+const allArticles: DocArticle[] = [
+  ...gettingStartedArticles,
+  ...apiReferenceArticles,
+  ...trustEngineArticles,
+  ...cdpArticles,
+  ...integrationsArticles,
+  ...tutorialsArticles,
+];
+
+export const docArticles: Record<string, DocArticle> = Object.fromEntries(
+  allArticles.map((article) => [article.slug, article])
+);
+
+export function getDocArticle(slug: string | undefined): DocArticle | undefined {
+  if (!slug) return undefined;
+  return docArticles[slug.replace(/^\/+|\/+$/g, '')];
+}
+
+/** Ordered flat list of internal article slugs, for prev/next navigation. */
+export const docArticleOrder: string[] = docsNav
+  .flatMap((cat) => cat.links)
+  .filter((l) => l.href.startsWith('/docs/'))
+  .map((l) => l.href.replace(/^\/docs\//, ''));

--- a/frontend/src/views/pages/resources/docs/types.ts
+++ b/frontend/src/views/pages/resources/docs/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Documentation content model.
+ *
+ * Articles are authored as a sequence of typed blocks so the renderer
+ * (`DocArticlePage`) can present them with the landing "ink + ember" theme
+ * without any per-article markup. Keep authoring in `content/*.ts`.
+ */
+
+import type { ComponentType } from 'react';
+
+export type DocBlock =
+  | { type: 'heading'; text: string }
+  | { type: 'subheading'; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'list'; ordered?: boolean; items: string[] }
+  | { type: 'code'; language?: string; code: string }
+  | { type: 'callout'; tone?: 'info' | 'warning' | 'success'; title?: string; text: string };
+
+export interface DocArticle {
+  /** Path after `/docs/` — e.g. `quickstart` or `cdp/profiles`. */
+  slug: string;
+  /** Category title this article belongs to (must match a `DocNavCategory.title`). */
+  category: string;
+  title: string;
+  description: string;
+  /** Human read estimate, e.g. `5 min`. */
+  readTime: string;
+  blocks: DocBlock[];
+}
+
+export interface DocNavLink {
+  name: string;
+  /** Absolute route, e.g. `/docs/quickstart` or the external `/api-docs`. */
+  href: string;
+}
+
+export interface DocNavCategory {
+  title: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  links: DocNavLink[];
+}


### PR DESCRIPTION
## Summary

Every link on the `/docs` portal except `/api-docs` pointed to a route that didn't exist, so 23 pages — `/docs/quickstart`, `/docs/installation`, `/docs/cdp/profiles`, `/docs/tutorials/best-practices`, etc. — all fell through to the 404 catch-all. This adds a real, content-driven docs system so **every link resolves to a themed page**.

## What's new

- **Content model + registry** (`docs/types.ts`, `docs/registry.ts`) — a typed `DocArticle`/`DocBlock` model and a registry that is the **single source of truth** for both the portal nav and the article map. `Docs.tsx` now imports the nav from the registry, so links and content can't drift apart.
- **23 authored articles** across the 6 categories with genuine, domain-accurate content:
  - *Getting Started* — Quick Start, Installation, Authentication, First Campaign
  - *API Reference* — Webhooks, SDKs, Rate Limits
  - *Trust Engine* — Signal Health (correct EMQ 35% / API 25% / Loss 20% / Stability 10% / Quality 10% weighting), Trust Gates (PASS/HOLD/BLOCK), Autopilot Rules (Advisory/Soft-Block/Hard-Block), Thresholds (70/40)
  - *CDP* — Profiles, Segments, Identity Resolution, Audience Sync
  - *Integrations* — Meta, Google, TikTok, CRM (OAuth + CAPI + hashed PII)
  - *Tutorials* — Video index, Use Cases, Best Practices, Troubleshooting
- **`DocArticlePage`** — a dynamic renderer (headings / paragraphs / lists / code / callouts) in the landing ink + ember theme, with a category sidebar, breadcrumb, prev/next, and a graceful in-context "not found" for unknown slugs (no more raw 404).
- **Route** — `path="/docs/*"` → lazy `DocArticlePage`, alongside the existing `/docs` portal.

## Verification

- **All 23 internal `/docs/*` nav links resolve to an authored article slug** — confirmed by an exact diff of nav hrefs vs authored slugs (0 mismatches).
- `tsc --noEmit -p tsconfig.build.json` ✅ · `eslint --max-warnings 0` ✅ · `npm run build` ✅ (`DocArticlePage` emitted as its own 6.94 kB lazy chunk).
- Inherits the dark-pinned public theme from #319.

## Note

As with the prior PRs, this only appears live after a **redeploy from `main`**.

Opened as a **draft** for review.

https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHtihz1vBizhZWFWkT7H9t)_